### PR TITLE
Adding: awk, sed, setenv, env, cd to the list of commands in iOS_system

### DIFF
--- a/Dependencies/ios_system/README.md
+++ b/Dependencies/ios_system/README.md
@@ -16,10 +16,10 @@ There are, first, shell commands (`ls`, `cp`, `rm`...), archive commands (`curl`
 
 For each set of commands, we need to provide the associated framework. Frameworks for small commands are in this project. Frameworks for interpreted languages are larger, and available separately: [python](https://github.com/holzschu/python_ios), [lua](https://github.com/holzschu/lua_ios) and [TeX](https://github.com/holzschu/lib-tex). Some commands (`curl`, `python`) require `OpenSSH` and `libssl2`, which you will have to download and compile separately.
 
-This `ios_system` framework has been successfully ported into a shell, [Blink](https://github.com/holzschu/blink) and into an editor, [iVim](https://github.com/holzschu/iVim). In both cases, it provides a Unix look-and-feel (well, mostly feel). 
+This `ios_system` framework has been successfully ported into two shells, [Blink](https://github.com/holzschu/blink) and [Terminal](https://github.com/louisdh/terminal) and into an editor, [iVim](https://github.com/holzschu/iVim). Each time, it provides a Unix look-and-feel (well, mostly feel). 
 
 **Issues:** In iOS, you cannot write in the `~` directory, only in `~/Documents/`, `~/Library/` and `~/tmp`. Most Unix programs assume the configuration files are in `$HOME`. 
-So either you redefine `$HOME` to `~/Documents/` or you set configuration variables (using `setenv`) to some other place.
+So either you redefine `$HOME` to `~/Documents/` or you set configuration variables (using `setenv`) to some other place. This is done in the `initializeEnvironment()` function. 
 
 Here's what I have:
 ```powershell
@@ -30,7 +30,7 @@ setenv CURL_HOME = $HOME/Documents/
 setenv HGRCPATH = $HOME/Documents/.hgrc/
 setenv SSL_CERT_FILE = $HOME/Documents/cacert.pem
 ```
-Your Mileage May Vary. 
+Your Mileage May Vary. Note that iOS already defines `$HOME` and `$PATH`. 
 
 ## Installation:
 

--- a/Dependencies/ios_system/curl.patch
+++ b/Dependencies/ios_system/curl.patch
@@ -1,6 +1,6 @@
 diff -Naur curl-105/config_iphone/curl_config.h curl/config_iphone/curl_config.h
 --- curl-105/config_iphone/curl_config.h	2017-05-24 02:47:37.000000000 +0200
-+++ curl/config_iphone/curl_config.h	2017-12-09 00:12:58.000000000 +0100
++++ curl/config_iphone/curl_config.h	2018-01-10 11:31:10.000000000 +0100
 @@ -410,6 +410,7 @@
  
  /* Define to 1 if you have the <libssh2.h> header file. */
@@ -36,7 +36,7 @@ diff -Naur curl-105/config_iphone/curl_config.h curl/config_iphone/curl_config.h
  /* #undef USE_NSS */
 diff -Naur curl-105/curl/include/curl/curl.h curl/curl/include/curl/curl.h
 --- curl-105/curl/include/curl/curl.h	2017-05-17 21:04:33.000000000 +0200
-+++ curl/curl/include/curl/curl.h	2017-12-09 00:12:58.000000000 +0100
++++ curl/curl/include/curl/curl.h	2018-01-10 11:31:10.000000000 +0100
 @@ -2391,7 +2391,7 @@
                             callback functions */
    CURLSHOPT_LAST  /* never use */
@@ -48,7 +48,7 @@ diff -Naur curl-105/curl/include/curl/curl.h curl/curl/include/curl/curl.h
  CURL_EXTERN CURLSHcode curl_share_cleanup(CURLSH *);
 diff -Naur curl-105/curl/lib/netrc.c curl/curl/lib/netrc.c
 --- curl-105/curl/lib/netrc.c	2016-11-04 22:42:50.000000000 +0100
-+++ curl/curl/lib/netrc.c	2017-12-09 00:12:58.000000000 +0100
++++ curl/curl/lib/netrc.c	2018-01-10 11:31:10.000000000 +0100
 @@ -69,7 +69,8 @@
  
    if(!netrcfile) {
@@ -61,8 +61,8 @@ diff -Naur curl-105/curl/lib/netrc.c curl/curl/lib/netrc.c
  #if defined(HAVE_GETPWUID_R) && defined(HAVE_GETEUID)
 diff -Naur curl-105/curl/lib/ssh.c curl/curl/lib/ssh.c
 --- curl-105/curl/lib/ssh.c	2017-05-17 21:04:33.000000000 +0200
-+++ curl/curl/lib/ssh.c	2017-12-11 17:22:53.000000000 +0100
-@@ -26,6 +26,13 @@
++++ curl/curl/lib/ssh.c	2018-01-10 12:15:13.000000000 +0100
+@@ -26,12 +26,19 @@
  
  #ifdef USE_LIBSSH2
  
@@ -76,6 +76,14 @@ diff -Naur curl-105/curl/lib/ssh.c curl/curl/lib/ssh.c
  #ifdef HAVE_LIMITS_H
  #  include <limits.h>
  #endif
+ 
+-#include <libssh2.h>
+-#include <libssh2_sftp.h>
++#include "libssh2.h"
++#include "libssh2_sftp.h"
+ 
+ #ifdef HAVE_FCNTL_H
+ #include <fcntl.h>
 @@ -714,6 +721,26 @@
    int err;
    int seekerr = CURL_SEEKFUNC_OK;
@@ -250,11 +258,124 @@ diff -Naur curl-105/curl/lib/ssh.c curl/curl/lib/ssh.c
        if(rc == LIBSSH2_ERROR_EAGAIN) {
          break;
        }
+diff -Naur curl-105/curl/lib/ssh.h curl/curl/lib/ssh.h
+--- curl-105/curl/lib/ssh.h	2016-11-04 22:42:50.000000000 +0100
++++ curl/curl/lib/ssh.h	2018-01-10 12:14:39.000000000 +0100
+@@ -25,8 +25,8 @@
+ #include "curl_setup.h"
+ 
+ #ifdef HAVE_LIBSSH2_H
+-#include <libssh2.h>
+-#include <libssh2_sftp.h>
++#include "libssh2.h"
++#include "libssh2_sftp.h"
+ #endif /* HAVE_LIBSSH2_H */
+ 
+ /****************************************************************************
+diff -Naur curl-105/curl/lib/urldata.h curl/curl/lib/urldata.h
+--- curl-105/curl/lib/urldata.h	2017-05-17 21:04:33.000000000 +0200
++++ curl/curl/lib/urldata.h	2018-01-10 12:14:47.000000000 +0100
+@@ -196,8 +196,8 @@
+ #endif
+ 
+ #ifdef HAVE_LIBSSH2_H
+-#include <libssh2.h>
+-#include <libssh2_sftp.h>
++#include "libssh2.h"
++#include "libssh2_sftp.h"
+ #endif /* HAVE_LIBSSH2_H */
+ 
+ /* Download buffer size, keep it fairly big for speed reasons */
+diff -Naur curl-105/curl/lib/version.c curl/curl/lib/version.c
+--- curl-105/curl/lib/version.c	2017-05-17 21:04:33.000000000 +0200
++++ curl/curl/lib/version.c	2018-01-10 12:15:01.000000000 +0100
+@@ -53,7 +53,7 @@
+ #endif
+ 
+ #ifdef USE_LIBSSH2
+-#include <libssh2.h>
++#include "libssh2.h"
+ #endif
+ 
+ #ifdef HAVE_LIBSSH2_VERSION
 diff -Naur curl-105/curl/src/tool_main.c curl/curl/src/tool_main.c
 --- curl-105/curl/src/tool_main.c	2016-07-06 23:44:05.000000000 +0200
-+++ curl/curl/src/tool_main.c	2017-12-09 00:12:58.000000000 +0100
-@@ -229,7 +229,11 @@
++++ curl/curl/src/tool_main.c	2018-01-10 15:05:06.000000000 +0100
+@@ -227,10 +227,89 @@
+ }
+ 
  /*
++ * iOS_system specifics: if the call is actually scp or sftp, we convert it to curl proper.
++ * scp user@host:~/distantFile localFile => curl scp://user@host/~/distantFile -o localFile
++ * scp user@host:/path/distantFile localFile => curl scp://user@host//path/distantFile -o localFile
++ * scp user@host:~/distantFile . => curl scp://user@host/~/distantFile -O
++ * scp user@host:~/distantFile /path/ => curl scp://user@host/~/distantFile -o /path/distantFile
++ * scp localFile user@host:~/path/       => curl -T localFile scp://user@host/~/path/localFile
++ */
++int curl_main(int argc, char *argv[]);
++
++static int scp_convert(int argc, char* argv[]) {
++    int argc2 = 0;
++    int i = 1;
++    char** argv2 = (char**) malloc((argc + 2) * sizeof(char*));
++    char* localFileName = NULL;
++    char* distantFileName = NULL;
++    char* protocol = argv[0];
++    argv2[0] = strdup("curl");
++    for (i = 1, argc2 = 1; i < argc; i++, argc2++) {
++        // it's just a flag:
++        if ((argv[i][0] == '-') || (distantFileName && localFileName)) { argv2[argc2] = strdup(argv[i]); continue; } 
++        char* position;
++        if ((position = strstr(argv[i], ":")) != NULL) {
++            // distant file
++            distantFileName = position + 1; // after the ":"
++            *position = 0; // split argv[i] into "user@host" and distantFileName
++            asprintf(argv2 + argc2, "%s://%s/%s", protocol, argv[i], distantFileName);
++            // get the actual filename
++            while ((position = strstr(distantFileName, "/")) != NULL) distantFileName = position + 1;
++        } else {
++            // Not beginning with "-", not containing ":", must be a local filename
++            // if it's ".", replace with -O
++            // if it's a directory, add name of file from previous argument at the end.
++            localFileName = argv[i];
++            if (!distantFileName) {
++                // local file before remote file: upload
++                argv2[argc2] = strdup("-T"); argc2++;
++                argv2[argc2] = strdup(argv[i]);
++            } else { // download
++                if ((strlen(argv[i]) == 1) && (strcmp(argv[i], ".") == 0)) argv2[argc2] = strdup("-O");
++                else {
++                    argv2[argc2] = strdup("-o"); argc2++;
++                    if (argv[i][strlen(argv[i]) - 1] == '/') {
++                        // if localFileName ends with '/' we assume it's a directory
++                        asprintf(argv2 + argc2, "%s%s", localFileName, distantFileName);
++                    } else {
++                        struct stat localFileBuf;
++                        bool localFileExists = (stat(localFileName, &localFileBuf) == 0);
++                        int localFileIsDir = S_ISDIR(localFileBuf.st_mode);
++                        if (localFileExists && localFileIsDir) {
++                            // localFileName exists *and* is a directory: concatenate distantFileName to directory
++                            asprintf(argv2 + argc2, "%s/%s", localFileName, distantFileName);
++                        } else {
++                            // all other cases: localFileName is name of output
++                            argv2[argc2] = strdup(argv[i]);
++                        }
++                    }
++                }
++            }
++        }
++    }
++    argv2[argc2] = NULL;
++#ifdef BLINKSHELL
++    int returnValue = curl_static_main(argc2, argv2);
++#else
++    int returnValue = curl_main(argc2, argv2);
++#endif
++    for (int i = 0; i < argc2; i++) free(argv2[i]);
++    free(argv2);
++    return returnValue;
++}
++/*
  ** curl tool main function.
  */
 -int main(int argc, char *argv[])
@@ -264,11 +385,16 @@ diff -Naur curl-105/curl/src/tool_main.c curl/curl/src/tool_main.c
 +int curl_main(int argc, char *argv[])
 +#endif
  {
++    // scp, sftp: edit arguments and relaunch
++    if ((strcmp(argv[0], "scp") == 0) || (strcmp(argv[0], "sftp") == 0)) {
++        return scp_convert(argc, argv);
++    }
    CURLcode result = CURLE_OK;
    struct GlobalConfig global;
+   memset(&global, 0, sizeof(global));
 diff -Naur curl-105/curl/src/tool_operate.c curl/curl/src/tool_operate.c
 --- curl-105/curl/src/tool_operate.c	2017-05-17 21:04:33.000000000 +0200
-+++ curl/curl/src/tool_operate.c	2017-12-09 00:12:58.000000000 +0100
++++ curl/curl/src/tool_operate.c	2018-01-10 11:31:10.000000000 +0100
 @@ -41,6 +41,9 @@
  
  #include "strcase.h"

--- a/Dependencies/ios_system/file_cmds.patch
+++ b/Dependencies/ios_system/file_cmds.patch
@@ -1,6 +1,6 @@
 diff -Naur file_cmds-272/chflags/chflags.c file_cmds/chflags/chflags.c
 --- file_cmds-272/chflags/chflags.c	2010-03-19 04:52:40.000000000 +0100
-+++ file_cmds/chflags/chflags.c	2017-12-12 23:37:11.000000000 +0100
++++ file_cmds/chflags/chflags.c	2018-01-10 11:30:57.000000000 +0100
 @@ -45,18 +45,20 @@
  #include <sys/types.h>
  #include <sys/stat.h>
@@ -49,7 +49,7 @@ diff -Naur file_cmds-272/chflags/chflags.c file_cmds/chflags/chflags.c
  		if (Hflag)
  			fts_options |= FTS_COMFOLLOW;
  		if (Lflag) {
-@@ -128,21 +135,32 @@
+@@ -128,21 +135,33 @@
  		val = strtol(flags, &ep, 8);
  		if (val < 0)
  			errno = ERANGE;
@@ -59,7 +59,7 @@ diff -Naur file_cmds-272/chflags/chflags.c file_cmds/chflags/chflags.c
 -                        errx(1, "invalid flags: %s", flags);
 +        if (errno) {
 +            // err(1, "invalid flags: %s", flags);
-+            fprintf(stderr, "chflags: invalid flags: %s\n", flags);
++            fprintf(stderr, "chflags: %s: invalid flags: %s\n", flags, strerror(errno));
 +            pthread_exit(NULL);
 +        }
 +        if (*ep) {
@@ -85,12 +85,13 @@ diff -Naur file_cmds-272/chflags/chflags.c file_cmds/chflags/chflags.c
 -		err(1, NULL);
 +    if ((ftsp = fts_open(++argv, fts_options , 0)) == NULL) {
 +		// err(1, NULL);
++        fprintf(stderr, "chflags: %s\n", strerror(errno));
 +        pthread_exit(NULL);
 +    }
  
  	for (rval = 0; (p = fts_read(ftsp)) != NULL;) {
  		switch (p->fts_info) {
-@@ -151,12 +169,14 @@
+@@ -151,12 +170,14 @@
  				fts_set(ftsp, p, FTS_SKIP);
  			continue;
  		case FTS_DNR:			/* Warn, chflag, continue. */
@@ -107,17 +108,17 @@ diff -Naur file_cmds-272/chflags/chflags.c file_cmds/chflags/chflags.c
  			rval = 1;
  			continue;
  		case FTS_SL:			/* Ignore. */
-@@ -179,7 +199,8 @@
+@@ -179,7 +200,8 @@
  		if (newflags == p->fts_statp->st_flags)
  			continue;
  		if ((*change_flags)(p->fts_accpath, (u_int)newflags) && !fflag) {
 -			warn("%s", p->fts_path);
 +			// warn("%s", p->fts_path);
-+            fprintf(stderr,"chflags: %s\n", p->fts_path);
++            fprintf(stderr,"chflags: %s: %s\n", p->fts_path, strerror(errno));
  			rval = 1;
  		} else if (vflag) {
  			(void)printf("%s", p->fts_path);
-@@ -190,8 +211,11 @@
+@@ -190,8 +212,11 @@
  			(void)printf("\n");
  		}
  	}
@@ -125,7 +126,7 @@ diff -Naur file_cmds-272/chflags/chflags.c file_cmds/chflags/chflags.c
 -		err(1, "fts_read");
 +    if (errno) {
 +		// err(1, "fts_read");
-+        fprintf(stderr, "chflags: fts_read\n");
++        fprintf(stderr, "chflags: fts_read: %s\n", strerror(errno));
 +        pthread_exit(NULL);
 +    }
  	exit(rval);
@@ -133,7 +134,7 @@ diff -Naur file_cmds-272/chflags/chflags.c file_cmds/chflags/chflags.c
  
 diff -Naur file_cmds-272/chmod/chmod.c file_cmds/chmod/chmod.c
 --- file_cmds-272/chmod/chmod.c	2013-10-05 00:39:00.000000000 +0200
-+++ file_cmds/chmod/chmod.c	2017-12-12 23:38:21.000000000 +0100
++++ file_cmds/chmod/chmod.c	2018-01-10 11:30:57.000000000 +0100
 @@ -49,7 +49,7 @@
  #include <sys/types.h>
  #include <sys/stat.h>
@@ -311,7 +312,7 @@ diff -Naur file_cmds-272/chmod/chmod.c file_cmds/chmod/chmod.c
 -			err(1, "Unable to allocate mode string");
 +        if (mode == NULL) {
 +			// err(1, "Unable to allocate mode string");
-+            fprintf(stderr, "chmod: Unable to allocate mode string\n");
++            fprintf(stderr, "chmod: Unable to allocate mode string: %s\n", strerror(errno));
 +            pthread_exit(NULL);
 +        }
  		/* Read the ACEs from STDIN */
@@ -352,7 +353,7 @@ diff -Naur file_cmds-272/chmod/chmod.c file_cmds/chmod/chmod.c
 -				errx(1, "Invalid file mode: %s", mode);
 +            if (errno) {
 +				// err(1, "Invalid file mode: %s", mode);
-+                fprintf(stderr, "chmod: Invalid file mode: %s\n", mode);
++                fprintf(stderr, "chmod: Invalid file mode: %s: %s\n", mode, strerror(errno));
 +                pthread_exit(NULL);
 +            }
 +            if (*ep) {
@@ -379,7 +380,7 @@ diff -Naur file_cmds-272/chmod/chmod.c file_cmds/chmod/chmod.c
 -		err(1, "fts_open");
 +    if ((ftsp = fts_open(++argv, fts_options, 0)) == NULL) {
 +		// err(1, "fts_open");
-+        fprintf(stderr, "chmod: fts_open\n");
++        fprintf(stderr, "chmod: fts_open: %s\n", strerror(errno));
 +        pthread_exit(NULL);
 +    }
  	for (rval = 0; (p = fts_read(ftsp)) != NULL;) {
@@ -412,7 +413,7 @@ diff -Naur file_cmds-272/chmod/chmod.c file_cmds/chmod/chmod.c
 -			if ((*change_mode)(p->fts_accpath, newmode) && !fflag) {
 -				warn("Unable to change file mode on %s", p->fts_path);
 +			if ((*change_mode)(p->fts_accpath, newmode) && !chmod_fflag) {
-+                fprintf(stderr, "chmod: Unable to change file mode on %s\n", p->fts_path);
++                fprintf(stderr, "chmod: Unable to change file mode on %s: %s\n", p->fts_path, strerror(errno));
 +                // warn("Unable to change file mode on %s", p->fts_path);
  				rval = 1;
  			} else {
@@ -425,7 +426,7 @@ diff -Naur file_cmds-272/chmod/chmod.c file_cmds/chmod/chmod.c
 -		err(1, "fts_read");
 +    if (errno) {
 +		// err(1, "fts_read");
-+        fprintf(stderr, "chmod: fts_read\n");
++        fprintf(stderr, "chmod: fts_read: %s\n", strerror(errno));
 +        pthread_exit(NULL);
 +    }
  #ifdef __APPLE__
@@ -442,7 +443,7 @@ diff -Naur file_cmds-272/chmod/chmod.c file_cmds/chmod/chmod.c
  	(void)fprintf(stderr,
 diff -Naur file_cmds-272/chmod/chmod_acl.c file_cmds/chmod/chmod_acl.c
 --- file_cmds-272/chmod/chmod_acl.c	2015-08-04 22:32:26.000000000 +0200
-+++ file_cmds/chmod/chmod_acl.c	2017-12-12 23:58:22.000000000 +0100
++++ file_cmds/chmod/chmod_acl.c	2018-01-10 11:30:57.000000000 +0100
 @@ -30,7 +30,7 @@
   * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
   * SUCH DAMAGE.
@@ -555,7 +556,7 @@ diff -Naur file_cmds-272/chmod/chmod_acl.c file_cmds/chmod/chmod_acl.c
 -		err(1, "malloc() failed");
 +    if (inbuf == NULL) {
 +		// err(1, "malloc() failed");
-+        fprintf(stderr, "chmod: malloc() failed\n");
++        fprintf(stderr, "chmod: malloc() failed: %s\n", strerror(errno));
 +        pthread_exit(NULL);
 +    }
  	strncpy(inbuf, input, MAX_ACL_TEXT_SIZE);
@@ -565,7 +566,7 @@ diff -Naur file_cmds-272/chmod/chmod_acl.c file_cmds/chmod/chmod_acl.c
 -		err(1, "acl_init() failed");
 +    if ((acl_input = acl_init(1)) == NULL) {
 +		// err(1, "acl_init() failed");
-+        fprintf(stderr, "chmod: acl_init() failed\n");
++        fprintf(stderr, "chmod: acl_init() failed: %s\n", strerror(errno));
 +        pthread_exit(NULL);
 +    }
  
@@ -577,7 +578,7 @@ diff -Naur file_cmds-272/chmod/chmod_acl.c file_cmds/chmod/chmod_acl.c
 -				err(1, "acl_create_entry() failed");
 +            if (0 != acl_create_entry(&acl_input, &newent)) {
 +				// err(1, "acl_create_entry() failed");
-+                fprintf(stderr, "chmod: acl_create_entry() failed\n");
++                fprintf(stderr, "chmod: acl_create_entry() failed: %s\n", strerror(errno));
 +                pthread_exit(NULL);
 +            }
  			if (0 != parse_entry(*bufp, newent)) {
@@ -600,7 +601,7 @@ diff -Naur file_cmds-272/chmod/chmod_acl.c file_cmds/chmod/chmod_acl.c
  	if (acl_get_tag_type(entry, &tag) != 0) {
 -		err(1, "Malformed ACL entry, no tag present");
 +		// err(1, "Malformed ACL entry, no tag present");
-+        fprintf(stderr, "chmod: Malformed ACL entry, no tag present\n");
++        fprintf(stderr, "chmod: Malformed ACL entry, no tag present: %s\n", strerror(errno));
 +        pthread_exit(NULL);
  	}
  	if (acl_get_flagset_np(entry, &flags) != 0){
@@ -609,12 +610,12 @@ diff -Naur file_cmds-272/chmod/chmod_acl.c file_cmds/chmod/chmod_acl.c
 -	if (acl_get_permset(entry, &perms) != 0)
 -		err(1, "Malformed ACL entry, no permset present");
 +		// err(1, "Unable to obtain flagset");
-+        fprintf(stderr, "chmod: Unable to obtain flagset\n");
++        fprintf(stderr, "chmod: Unable to obtain flagset: %s\n", strerror(errno));
 +        pthread_exit(NULL);
 +	}
 +    if (acl_get_permset(entry, &perms) != 0) {
 +		// err(1, "Malformed ACL entry, no permt present");
-+        fprintf(stderr, "chmod: Malformed ACL entry, no permt present\n");
++        fprintf(stderr, "chmod: Malformed ACL entry, no permt present: %s\n", strerror(errno));
 +        pthread_exit(NULL);
 +    }
  	
@@ -641,12 +642,12 @@ diff -Naur file_cmds-272/chmod/chmod_acl.c file_cmds/chmod/chmod_acl.c
 -		err(1, "No tag type present in entry");
 +    if (0 != acl_get_tag_type(a, &atag)) {
 +		// err(1, "No tag type present in entry");
-+        fprintf(stderr, "chmod: No tag type present in entry\n");
++        fprintf(stderr, "chmod: No tag type present in entry: %s\n", strerror(errno));
 +        pthread_exit(NULL);
 +    }
 +    if (0!= acl_get_tag_type(b, &btag)) {
 +		// err(1, "No tag type present in entry");
-+        fprintf(stderr, "chmod: No tag type present in entry\n");
++        fprintf(stderr, "chmod: No tag type present in entry: %s\n", strerror(errno));
 +        pthread_exit(NULL);
 +    }
  
@@ -660,7 +661,7 @@ diff -Naur file_cmds-272/chmod/chmod_acl.c file_cmds/chmod/chmod_acl.c
 -		err(1, "error fetching permissions");
 +        (acl_get_flagset_np(b, &bflags) != 0)) {
 +		// err(1, "error fetching permissions");
-+        fprintf(stderr, "chmod: error fetching permissions\n");
++        fprintf(stderr, "chmod: error fetching permissions: %s\n", strerror(errno));
 +        pthread_exit(NULL);
 +    }
  
@@ -674,7 +675,7 @@ diff -Naur file_cmds-272/chmod/chmod_acl.c file_cmds/chmod/chmod_acl.c
 -					err(1, "Unable to get flagset");
 +                if (0 != acl_get_flagset_np(modifier, &mflags)) {
 +					// err(1, "Unable to get flagset");
-+                    fprintf(stderr, "chmod: Unable to get flagset\n");
++                    fprintf(stderr, "chmod: Unable to get flagset: %s\n", strerror(errno));
 +                    pthread_exit(NULL);
 +                }
  				
@@ -682,7 +683,7 @@ diff -Naur file_cmds-272/chmod/chmod_acl.c file_cmds/chmod/chmod_acl.c
 -					err(1, "Unable to get flagset");
 +                if (0 != acl_get_flagset_np(entry, &eflags)) {
 +					// err(1, "Unable to get flagset");
-+                    fprintf(stderr, "chmod: Unable to get flagset\n");
++                    fprintf(stderr, "chmod: Unable to get flagset: %s\n", strerror(errno));
 +                    pthread_exit(NULL);
 +                }
  					
@@ -696,7 +697,7 @@ diff -Naur file_cmds-272/chmod/chmod_acl.c file_cmds/chmod/chmod_acl.c
 -		err(1, "error computing ACL modification");
 +        (acl_get_flagset_np(modifier, &mflags) != 0)) {
 +		// err(1, "error computing ACL modification");
-+        fprintf(stderr, "chmod: error computing ACL modification\n");
++        fprintf(stderr, "chmod: error computing ACL modification: %s\n", strerror(errno));
 +        pthread_exit(NULL);
 +    }
  
@@ -710,7 +711,7 @@ diff -Naur file_cmds-272/chmod/chmod_acl.c file_cmds/chmod/chmod_acl.c
 -		err(1, "error computing ACL modification");
 +        (acl_get_flagset_np(modifier, &mflags) != 0)) {
 +		// err(1, "error computing ACL modification");
-+        fprintf(stderr, "chmod: error computing ACL modification\n");
++        fprintf(stderr, "chmod: error computing ACL modification: %s\n", strerror(errno));
 +        pthread_exit(NULL);
 +    }
  
@@ -724,7 +725,7 @@ diff -Naur file_cmds-272/chmod/chmod_acl.c file_cmds/chmod/chmod_acl.c
 -				err(1, "acl_create_entry() failed");
 +            if (0 != acl_create_entry_np(&oacl, &newent, position)) {
 +				// err(1, "acl_create_entry() failed");
-+                fprintf(stderr, "chmod: acl_create_entry() failed\n");
++                fprintf(stderr, "chmod: acl_create_entry() failed: %s\n", strerror(errno));
 +                pthread_exit(NULL);
 +            }
  			acl_copy_entry(newent, modifier);
@@ -738,7 +739,7 @@ diff -Naur file_cmds-272/chmod/chmod_acl.c file_cmds/chmod/chmod_acl.c
 -				err(1, "acl_create_entry() failed");
 +            if (0!= acl_create_entry_np(&oacl, &newent, cpos)) {
 +				// err(1, "acl_create_entry() failed");
-+                fprintf(stderr, "chmod: acl_create_entry() failed\n");
++                fprintf(stderr, "chmod: acl_create_entry() failed: %s\n", strerror(errno));
 +                pthread_exit(NULL);
 +            }
  			acl_copy_entry(newent, modifier);
@@ -780,7 +781,7 @@ diff -Naur file_cmds-272/chmod/chmod_acl.c file_cmds/chmod/chmod_acl.c
 -				err(1, "Invalid entry number '%s'", path);
 +                            &rentry)) {
 +				// err(1, "Invalid entry number '%s'", path);
-+                fprintf(stderr, "chmod: Invalid entry number '%s'\n", path);
++                fprintf(stderr, "chmod: Invalid entry number '%s': %s\n", path, strerror(errno));
 +                pthread_exit(NULL);
 +            }
  			
@@ -791,13 +792,13 @@ diff -Naur file_cmds-272/chmod/chmod_acl.c file_cmds/chmod/chmod_acl.c
 -			err(1, "acl_create_entry() failed");
 +            if (0 != acl_delete_entry(oacl, rentry)) {
 +				// err(1, "Unable to delete entry '%s'", path);
-+                fprintf(stderr, "chmod: Unable to delete entry '%s'\n", path);
++                fprintf(stderr, "chmod: Unable to delete entry '%s': %s\n", path, strerror(errno));
 +                pthread_exit(NULL);
 +            }
 +		}
 +        if (0!= acl_create_entry_np(&oacl, &newent, position)) {
 +			// err(1, "acl_create_entry() failed");
-+            fprintf(stderr, "chmod: acl_create_entry() failed\n");
++            fprintf(stderr, "chmod: acl_create_entry() failed: %s\n", strerror(errno));
 +            pthread_exit(NULL);
 +        }
  		acl_copy_entry(newent, modifier);
@@ -824,22 +825,22 @@ diff -Naur file_cmds-272/chmod/chmod_acl.c file_cmds/chmod/chmod_acl.c
  		if (fsec == NULL) {
 -			err(1, "filesec_init() failed");
 +			// err(1, "filesec_init() failed");
-+            fprintf(stderr, "chmod: filesec_init() failed\n");
++            fprintf(stderr, "chmod: filesec_init() failed: %s\n", strerror(errno));
 +            pthread_exit(NULL);
  		}
  		if (filesec_set_property(fsec, FILESEC_ACL, _FILESEC_REMOVE_ACL) != 0) {
 -			err(1, "filesec_set_property() failed");
 +            // err(1, "filesec_set_property() failed");
-+			fprintf(stderr, "chmod: filesec_set_property() failed\n");
++            fprintf(stderr, "chmod: filesec_set_property() failed: %s\n", strerror(errno));
 +            pthread_exit(NULL);
                  }
  		if (follow) {
  			if (chmodx_np(path, fsec) != 0) {
 -                                if (!fflag) {
 -					warn("Failed to clear ACL on file %s", path);
-+                                if (!chmod_fflag) {
++                if (!chmod_fflag) {
 +					// warn("Failed to clear ACL on file %s", path);
-+                    fprintf(stderr, "chmod: Failed to clear ACL on file %s\n", path);
++                    fprintf(stderr, "chmod: Failed to clear ACL on file %s: %s\n", path, strerror(errno));
  				}
  				retval = 1;
  			}
@@ -850,7 +851,7 @@ diff -Naur file_cmds-272/chmod/chmod_acl.c file_cmds/chmod/chmod_acl.c
 -					if (!fflag) {
 -						warn("Failed to clear ACL on file %s", path);
 +					if (!chmod_fflag) {
-+                        fprintf(stderr, "chmod: Failed to clear ACL on file %s\n", path);
++                        fprintf(stderr, "chmod: Failed to clear ACL on file %s: %s\n", path, strerror(errno));
 +                        // warn("Failed to clear ACL on file %s", path);
  					}
  					retval = 1;
@@ -861,7 +862,7 @@ diff -Naur file_cmds-272/chmod/chmod_acl.c file_cmds/chmod/chmod_acl.c
 -					warn("Failed to open file %s", path);
 +				if (!chmod_fflag) {
 +					// warn("Failed to open file %s", path);
-+                    fprintf(stderr, "chmod: Failed to open file %s\n", path);
++                    fprintf(stderr, "chmod: Failed to open file %s: %s\n", path, strerror(errno));
  				}
  				retval = 1;
  			}
@@ -873,7 +874,7 @@ diff -Naur file_cmds-272/chmod/chmod_acl.c file_cmds/chmod/chmod_acl.c
 -				err(1, "acl_init() failed");
 +            if ((oacl = acl_init(1)) == NULL) {
 +				// err(1, "acl_init() failed");
-+                fprintf(stderr, "chmod: acl_init() failed\n");
++                fprintf(stderr, "chmod: acl_init() failed: %s\n", strerror(errno));
 +                pthread_exit(NULL);
 +            }
  			flag_new_acl = 1;
@@ -887,7 +888,7 @@ diff -Naur file_cmds-272/chmod/chmod_acl.c file_cmds/chmod/chmod_acl.c
 -				err(1, "acl_init() failed");
 +            if ((facl = acl_init(1)) == NULL) {
 +				//err(1, "acl_init() failed");
-+                fprintf(stderr, "chmod: acl_init() failed\n");
++                fprintf(stderr, "chmod: acl_init() failed: %s\n", strerror(errno));
 +                pthread_exit(NULL);
 +            }
  			for (aindex = 0; 
@@ -898,7 +899,7 @@ diff -Naur file_cmds-272/chmod/chmod_acl.c file_cmds/chmod/chmod_acl.c
  				acl_entry_t fent = NULL;
  				if (acl_get_flagset_np(entry, &eflags) != 0) {
 -					err(1, "Unable to obtain flagset");
-+                    fprintf(stderr,  "chmod: Unable to obtain flagset\n");
++                    fprintf(stderr,  "chmod: Unable to obtain flagset: %s\n", strerror(errno));
 +                    pthread_exit(NULL);
 +                    // err(1, "Unable to obtain flagset");
  				}
@@ -944,14 +945,14 @@ diff -Naur file_cmds-272/chmod/chmod_acl.c file_cmds/chmod/chmod_acl.c
 -			if (!fflag)
 -				warn("Failed to set ACL on file '%s'", path);
 +			if (!chmod_fflag)
-+                fprintf(stderr, "chmod: Failed to set ACL on file '%s'\n", path);
++                fprintf(stderr, "chmod: Failed to set ACL on file '%s': %s\n", path, strerror(errno));
 +            // warn("Failed to set ACL on file '%s'", path);
  			retval = 1;
  		}
  	}
 diff -Naur file_cmds-272/chown/chown.c file_cmds/chown/chown.c
 --- file_cmds-272/chown/chown.c	2013-10-05 00:39:00.000000000 +0200
-+++ file_cmds/chown/chown.c	2017-12-12 23:58:22.000000000 +0100
++++ file_cmds/chown/chown.c	2018-01-10 11:30:57.000000000 +0100
 @@ -50,7 +50,7 @@
  #include <sys/param.h>
  #include <sys/stat.h>
@@ -1040,17 +1041,21 @@ diff -Naur file_cmds-272/chown/chown.c file_cmds/chown/chown.c
  			*cp++ = '\0';
  			a_gid(cp);
  		}
-@@ -170,7 +177,8 @@
+@@ -169,8 +176,11 @@
+ 		a_gid(*argv);
  	}
  
- 	if ((ftsp = fts_open(++argv, fts_options, 0)) == NULL)
+-	if ((ftsp = fts_open(++argv, fts_options, 0)) == NULL)
 -		err(1, NULL);
++    if ((ftsp = fts_open(++argv, fts_options, 0)) == NULL) {
++        fprintf(stderr, "chown: %s\n", strerror(errno));
 +        pthread_exit(NULL);
 +        //err(1, NULL);
++    }
  
  	for (rval = 0; (p = fts_read(ftsp)) != NULL;) {
  		symlink_found = 0;
-@@ -180,12 +188,14 @@
+@@ -180,12 +190,14 @@
  				fts_set(ftsp, p, FTS_SKIP);
  			continue;
  		case FTS_DNR:			/* Warn, chown. */
@@ -1067,7 +1072,7 @@ diff -Naur file_cmds-272/chown/chown.c file_cmds/chown/chown.c
  			rval = 1;
  			continue;
  		case FTS_SL:
-@@ -202,7 +212,8 @@
+@@ -202,7 +214,8 @@
  				if (unix2003_compat) {
  					if (Hflag || Lflag) {       /* -H or -L was specified */
  						if (p->fts_errno) {
@@ -1077,17 +1082,17 @@ diff -Naur file_cmds-272/chown/chown.c file_cmds/chown/chown.c
  							rval = 1;
  							continue;
  						}
-@@ -234,7 +245,8 @@
+@@ -234,7 +247,8 @@
  		}
  	}
  	if (errno)
 -		err(1, "fts_read");
 +		//err(1, "fts_read");
-+        fprintf(stderr, "chown: fts_read\n");
++        fprintf(stderr, "chown: fts_read: %s\n", strerror(errno));
  	exit(rval);
  }
  
-@@ -267,8 +279,11 @@
+@@ -267,8 +281,11 @@
  
  	errno = 0;
  	val = strtoul(name, &ep, 10);
@@ -1101,17 +1106,17 @@ diff -Naur file_cmds-272/chown/chown.c file_cmds/chown/chown.c
  	return (uid_t)val;
  }
  
-@@ -282,7 +297,8 @@
+@@ -282,7 +299,8 @@
  	/* Check for chown without being root. */
  	if (errno != EPERM || (uid != (uid_t)-1 &&
  	    euid == (uid_t)-1 && (euid = geteuid()) != 0)) {
 -		warn("%s", file);
 +		// warn("%s", file);
-+        fprintf(stderr, "chown: %s\n", file);
++        fprintf(stderr, "chown: %s: %s\n", file, strerror(errno));
  		return;
  	}
  
-@@ -292,11 +308,13 @@
+@@ -292,11 +310,13 @@
  		ngroups = getgroups(NGROUPS_MAX, groups);
  		while (--ngroups >= 0 && gid != groups[ngroups]);
  		if (ngroups < 0) {
@@ -1123,13 +1128,13 @@ diff -Naur file_cmds-272/chown/chown.c file_cmds/chown/chown.c
  	}
 -	warn("%s", file);
 +	// warn("%s", file);
-+    fprintf(stderr, "chown: %s\n", file);
++    fprintf(stderr, "chown: %s: %s\n", file, strerror(errno));
  }
  
  void
 diff -Naur file_cmds-272/cksum/cksum.c file_cmds/cksum/cksum.c
 --- file_cmds-272/cksum/cksum.c	2013-10-05 00:39:00.000000000 +0200
-+++ file_cmds/cksum/cksum.c	2017-12-12 23:58:22.000000000 +0100
++++ file_cmds/cksum/cksum.c	2018-01-10 11:30:57.000000000 +0100
 @@ -52,7 +52,7 @@
  
  #include <sys/types.h>
@@ -1139,10 +1144,11 @@ diff -Naur file_cmds-272/cksum/cksum.c file_cmds/cksum/cksum.c
  #include <fcntl.h>
  #include <stdint.h>
  #include <stdio.h>
-@@ -61,11 +61,12 @@
+@@ -61,11 +61,13 @@
  #include <unistd.h>
  
  #include "extern.h"
++#include <errno.h>
 +#include "ios_error.h" // remap exit to pthread_exit
  
  static void usage(void);
@@ -1153,7 +1159,7 @@ diff -Naur file_cmds-272/cksum/cksum.c file_cmds/cksum/cksum.c
  {
  	uint32_t val;
  	int ch, fd, rval;
-@@ -75,6 +76,7 @@
+@@ -75,6 +77,7 @@
  	void (*pfncn)(char *, u_int32_t, off_t);
  	
  	cfncn=NULL;
@@ -1161,7 +1167,7 @@ diff -Naur file_cmds-272/cksum/cksum.c file_cmds/cksum/cksum.c
  
  	if(*argv) {
  	  if ((p = rindex(argv[0], '/')) == NULL)
-@@ -102,10 +104,11 @@
+@@ -102,10 +105,11 @@
  					cfncn = csum2;
  					pfncn = psum2;
  				} else if (!strcmp(optarg, "3")) {
@@ -1175,12 +1181,12 @@ diff -Naur file_cmds-272/cksum/cksum.c file_cmds/cksum/cksum.c
  					usage();
  				}
  				break;
-@@ -124,13 +127,15 @@
+@@ -124,13 +128,15 @@
  		if (*argv) {
  			fn = *argv++;
  			if ((fd = open(fn, O_RDONLY, 0)) < 0) {
 -				warn("%s", fn);
-+                fprintf(stderr, "chksum: %s\n", fn);
++                fprintf(stderr, "chksum: %s: %s\n", fn, strerror(errno));
 +                // warn("%s", fn);
  				rval = 1;
  				continue;
@@ -1188,14 +1194,14 @@ diff -Naur file_cmds-272/cksum/cksum.c file_cmds/cksum/cksum.c
  		}
  		if (cfncn(fd, &val, &len)) {
 -			warn("%s", fn ? fn : "stdin");
-+            fprintf(stderr, "chksum: %s\n", fn ? fn : "stdin");
++            fprintf(stderr, "chksum: %s: %s\n", fn ? fn : "stdin", strerror(errno));
 +            // warn("%s", fn ? fn : "stdin");
  			rval = 1;
  		} else
  			pfncn(fn, val, len);
 diff -Naur file_cmds-272/cksum/crc32.c file_cmds/cksum/crc32.c
 --- file_cmds-272/cksum/crc32.c	2012-03-14 00:22:38.000000000 +0100
-+++ file_cmds/cksum/crc32.c	2017-12-09 00:12:38.000000000 +0100
++++ file_cmds/cksum/crc32.c	2018-01-10 11:30:57.000000000 +0100
 @@ -98,7 +98,7 @@
  uint32_t crc32_total = 0;
  
@@ -1207,7 +1213,7 @@ diff -Naur file_cmds-272/cksum/crc32.c file_cmds/cksum/crc32.c
      ssize_t nr;
 diff -Naur file_cmds-272/cksum/extern.h file_cmds/cksum/extern.h
 --- file_cmds-272/cksum/extern.h	2006-12-09 07:36:49.000000000 +0100
-+++ file_cmds/cksum/extern.h	2017-12-09 00:12:38.000000000 +0100
++++ file_cmds/cksum/extern.h	2018-01-10 11:30:57.000000000 +0100
 @@ -43,5 +43,5 @@
  void	psum2(char *, uint32_t, off_t);
  int	csum1(int, uint32_t *, off_t *);
@@ -1217,7 +1223,7 @@ diff -Naur file_cmds-272/cksum/extern.h file_cmds/cksum/extern.h
  __END_DECLS
 diff -Naur file_cmds-272/compress/compress.c file_cmds/compress/compress.c
 --- file_cmds-272/compress/compress.c	2013-10-05 00:39:00.000000000 +0200
-+++ file_cmds/compress/compress.c	2017-12-12 23:58:45.000000000 +0100
++++ file_cmds/compress/compress.c	2018-01-10 11:30:57.000000000 +0100
 @@ -56,28 +56,31 @@
  #include <unistd.h>
  
@@ -1313,7 +1319,7 @@ diff -Naur file_cmds-272/compress/compress.c file_cmds/compress/compress.c
  			if (unlink(out))
 diff -Naur file_cmds-272/cp/cp.c file_cmds/cp/cp.c
 --- file_cmds-272/cp/cp.c	2017-04-17 19:33:52.000000000 +0200
-+++ file_cmds/cp/cp.c	2017-12-12 23:58:22.000000000 +0100
++++ file_cmds/cp/cp.c	2018-01-10 11:30:57.000000000 +0100
 @@ -62,7 +62,7 @@
  #include <sys/types.h>
  #include <sys/stat.h>
@@ -1492,7 +1498,7 @@ diff -Naur file_cmds-272/cp/cp.c file_cmds/cp/cp.c
 -		err(1, "%s", to.p_path);
 +    if (r == -1 && errno != ENOENT) {
 +		// err(1, "%s", to.p_path);
-+        fprintf(stderr, "cp: %s\n", to.p_path);
++        fprintf(stderr, "cp: %s: %s\n", to.p_path, strerror(errno));
 +        pthread_exit(NULL);
 +    }
  	if (r == -1 || !S_ISDIR(to_stat.st_mode)) {
@@ -1544,7 +1550,7 @@ diff -Naur file_cmds-272/cp/cp.c file_cmds/cp/cp.c
 -		err(1, "fts_open");
 +    if ((ftsp = fts_open(argv, fts_options, NULL)) == NULL) {
 +		// err(1, "fts_open");
-+        fprintf(stderr, "cp: fts_open\n");
++        fprintf(stderr, "cp: fts_open: %s\n", strerror(errno));
 +        pthread_exit(NULL);
 +    }
  	for (badcp = rval = 0; (curr = fts_read(ftsp)) != NULL; badcp = 0) {
@@ -1597,7 +1603,7 @@ diff -Naur file_cmds-272/cp/cp.c file_cmds/cp/cp.c
  				if (copyfile(curr->fts_path, to.p_path, NULL, COPYFILE_ACL)<0)
 -					warn("%s: unable to copy ACL to %s", curr->fts_path, to.p_path);
 +					// warn("%s: unable to copy ACL to %s", curr->fts_path, to.p_path);
-+                    fprintf(stderr, "cp: %s: unable to copy ACL to %s\n", curr->fts_path, to.p_path);
++                    fprintf(stderr, "cp: %s: unable to copy ACL to %s: %s\n", curr->fts_path, to.p_path, strerror(errno));
  #else  /* !__APPLE__ */
  				if (preserve_dir_acls(curr->fts_statp,
  				    curr->fts_accpath, to.p_path) != 0)
@@ -1607,7 +1613,7 @@ diff -Naur file_cmds-272/cp/cp.c file_cmds/cp/cp.c
  					if (chmod(to.p_path, mode & mask) != 0){
 -						warn("chmod: %s", to.p_path);
 +						// warn("chmod: %s", to.p_path);
-+                        fprintf(stderr, "cp: chmod: %s\n", to.p_path);
++                        fprintf(stderr, "cp: chmod: %s: %s\n", to.p_path, strerror(errno));
  						rval = 1;
  					}
  			}
@@ -1648,12 +1654,12 @@ diff -Naur file_cmds-272/cp/cp.c file_cmds/cp/cp.c
  					  curr->fts_statp->st_mode | S_IRWXU) < 0) {
  					if (COMPAT_MODE("bin/cp", "unix2003")) {
 -						warn("%s", to.p_path);
-+                        fprintf(stderr, "cp: %s\n", to.p_path);
++                        fprintf(stderr, "cp: %s: %s\n", to.p_path, strerror(errno));
 +                        // warn("%s", to.p_path);
  					} else {
 -						err(1, "%s", to.p_path);
 +						// err(1, "%s", to.p_path);
-+                        fprintf(stderr, "cp: %s\n", to.p_path);
++                        fprintf(stderr, "cp: %s: %s\n", to.p_path, strerror(errno));
 +                        pthread_exit(NULL);
  					}
  				}
@@ -1662,11 +1668,11 @@ diff -Naur file_cmds-272/cp/cp.c file_cmds/cp/cp.c
  				if (COMPAT_MODE("bin/cp", "unix2003")) {
 -					warn("%s", to.p_path);
 +					// warn("%s", to.p_path);
-+                    fprintf(stderr, "cp: %s\n", to.p_path);
++                    fprintf(stderr, "cp: %s: %s\n", to.p_path, strerror(errno));
  				} else {
 -					err(1, "%s", to.p_path);
 +					// err(1, "%s", to.p_path);
-+                    fprintf(stderr, "cp: %s\n", to.p_path);
++                    fprintf(stderr, "cp: %s: %s\n", to.p_path, strerror(errno));
 +                    pthread_exit(NULL);
  				}
  			}
@@ -1681,7 +1687,7 @@ diff -Naur file_cmds-272/cp/cp.c file_cmds/cp/cp.c
  			if (!Xflag) {
  				if (copyfile(curr->fts_path, to.p_path, NULL, COPYFILE_XATTR) < 0)
 -					warn("%s: unable to copy extended attributes to %s", curr->fts_path, to.p_path);
-+                    fprintf(stderr, "cp: %s: unable to copy extended attributes to %s\n", curr->fts_path, to.p_path);
++                    fprintf(stderr, "cp: %s: unable to copy extended attributes to %s: %s\n", curr->fts_path, to.p_path, strerror(errno));
 +                // warn("%s: unable to copy extended attributes to %s", curr->fts_path, to.p_path);
  				/* ACL and mtime set in postorder traversal */
  			}
@@ -1699,7 +1705,7 @@ diff -Naur file_cmds-272/cp/cp.c file_cmds/cp/cp.c
 -	fts_close(ftsp);
 +    fts_close(ftsp);
 +    if (errno) {
-+        fprintf(stderr, "cp: fts_read\n");
++        fprintf(stderr, "cp: fts_read: %s\n", strerror(errno));
 +        pthread_exit(NULL);
 +		// err(1, "fts_read");
 +    }
@@ -1708,7 +1714,7 @@ diff -Naur file_cmds-272/cp/cp.c file_cmds/cp/cp.c
  
 diff -Naur file_cmds-272/cp/extern.h file_cmds/cp/extern.h
 --- file_cmds-272/cp/extern.h	2017-04-17 19:33:52.000000000 +0200
-+++ file_cmds/cp/extern.h	2017-12-09 00:12:38.000000000 +0100
++++ file_cmds/cp/extern.h	2018-01-10 11:30:57.000000000 +0100
 @@ -37,11 +37,11 @@
  } PATH_T;
  
@@ -1732,7 +1738,7 @@ diff -Naur file_cmds-272/cp/extern.h file_cmds/cp/extern.h
  __END_DECLS
 diff -Naur file_cmds-272/cp/utils.c file_cmds/cp/utils.c
 --- file_cmds-272/cp/utils.c	2017-04-17 19:33:52.000000000 +0200
-+++ file_cmds/cp/utils.c	2017-12-12 23:58:22.000000000 +0100
++++ file_cmds/cp/utils.c	2018-01-10 11:30:57.000000000 +0100
 @@ -43,7 +43,7 @@
  #include <sys/mman.h>
  #endif
@@ -1765,7 +1771,7 @@ diff -Naur file_cmds-272/cp/utils.c file_cmds/cp/utils.c
  
  	if ((from_fd = open(entp->fts_path, O_RDONLY, 0)) == -1) {
 -		warn("%s", entp->fts_path);
-+        fprintf(stderr, "cp: %s\n", entp->fts_path);
++        fprintf(stderr, "cp: %s: %s\n", entp->fts_path, strerror(errno));
 +        // warn("%s", entp->fts_path);
  		return (1);
  	}
@@ -1796,7 +1802,7 @@ diff -Naur file_cmds-272/cp/utils.c file_cmds/cp/utils.c
  			int error = clonefile(entp->fts_path, to.p_path, 0);
  			if (error)
 -				warn("%s: clonefile failed", to.p_path);
-+                fprintf(stderr, "cp: %s: clonefile failed\n", to.p_path);
++                fprintf(stderr, "cp: %s: clonefile failed: %s\n", to.p_path, strerror(errno));
 +            // warn("%s: clonefile failed", to.p_path);
  			(void)close(from_fd);
  			return error == 0 ? 0 : 1;
@@ -1828,7 +1834,7 @@ diff -Naur file_cmds-272/cp/utils.c file_cmds/cp/utils.c
  			int error = clonefile(entp->fts_path, to.p_path, 0);
  			if (error)
 -				warn("%s: clonefile failed", to.p_path);
-+                fprintf(stderr, "cp: %s: clonefile failed\n", to.p_path);
++                fprintf(stderr, "cp: %s: clonefile failed: %s\n", to.p_path, strerror(errno));
 +            //  warn("%s: clonefile failed", to.p_path);
  			(void)close(from_fd);
  			return error == 0 ? 0 : 1;
@@ -1838,7 +1844,7 @@ diff -Naur file_cmds-272/cp/utils.c file_cmds/cp/utils.c
  
  	if (to_fd == -1) {
 -		warn("%s", to.p_path);
-+        fprintf(stderr, "cp: %s\n", to.p_path);
++        fprintf(stderr, "cp: %s: %s\n", to.p_path, strerror(errno));
 +        // warn("%s", to.p_path);
  		(void)close(from_fd);
  		return (1);
@@ -1848,13 +1854,13 @@ diff -Naur file_cmds-272/cp/utils.c file_cmds/cp/utils.c
  		   && fchmod(to_fd, mode & ~(S_IRWXG|S_IRWXO))) {
  		       if (errno != EPERM) /* we have write access but do not own the file */
 -			       warn("%s: fchmod failed", to.p_path);
-+                   fprintf(stderr, "cp: %s: fchmod failed\n", to.p_path);
++                   fprintf(stderr, "cp: %s: fchmod failed: %s\n", to.p_path, strerror(errno));
 +                   // warn("%s: fchmod failed", to.p_path);
  		       mode = 0;
  	       }
         } else {
 -	       warn("%s", to.p_path);
-+           fprintf(stderr, "cp: %s\n", to.p_path);
++           fprintf(stderr, "cp: %s: %s\n", to.p_path, strerror(errno));
 +           // warn("%s", to.p_path);
         }
  	/*
@@ -1864,7 +1870,7 @@ diff -Naur file_cmds-272/cp/utils.c file_cmds/cp/utils.c
  		if ((p = mmap(NULL, (size_t)fs->st_size, PROT_READ,
  		    MAP_SHARED, from_fd, (off_t)0)) == MAP_FAILED) {
 -			warn("%s", entp->fts_path);
-+            fprintf(stderr, "cp: %s\n", entp->fts_path);
++            fprintf(stderr, "cp: %s: %s\n", entp->fts_path, strerror(errno));
 +            // warn("%s", entp->fts_path);
  			rval = 1;
  		} else {
@@ -1874,14 +1880,14 @@ diff -Naur file_cmds-272/cp/utils.c file_cmds/cp/utils.c
  			}
  			if (wcount != (ssize_t)wresid) {
 -				warn("%s", to.p_path);
-+                fprintf(stderr, "cp: %s\n", to.p_path);
++                fprintf(stderr, "cp: %s: %s\n", to.p_path, strerror(errno));
 +                // warn("%s", to.p_path);
  				rval = 1;
  			}
  			/* Some systems don't unmap on close(2). */
  			if (munmap(p, fs->st_size) < 0) {
 -				warn("%s", entp->fts_path);
-+                fprintf(stderr, "cp: %s\n", entp->fts_path);
++                fprintf(stderr, "cp: %s: %s\n", entp->fts_path, strerror(errno));
 +                // warn("%s", entp->fts_path);
  				rval = 1;
  			}
@@ -1891,7 +1897,7 @@ diff -Naur file_cmds-272/cp/utils.c file_cmds/cp/utils.c
  			}
  			if (wcount != (ssize_t)wresid) {
 -				warn("%s", to.p_path);
-+                fprintf(stderr, "cp: %s\n", to.p_path);
++                fprintf(stderr, "cp: %s: %s\n", to.p_path, strerror(errno));
 +                // warn("%s", to.p_path);
  				rval = 1;
  				break;
@@ -1899,7 +1905,7 @@ diff -Naur file_cmds-272/cp/utils.c file_cmds/cp/utils.c
  		}
  		if (rcount < 0) {
 -			warn("%s", entp->fts_path);
-+            fprintf(stderr, "cp: %s\n", entp->fts_path);
++            fprintf(stderr, "cp: %s: %s\n", entp->fts_path, strerror(errno));
 +            // warn("%s", entp->fts_path);
  			rval = 1;
  		}
@@ -1909,14 +1915,14 @@ diff -Naur file_cmds-272/cp/utils.c file_cmds/cp/utils.c
  	if (mode != 0)
  		if (fchmod(to_fd, mode))
 -			warn("%s: fchmod failed", to.p_path);
-+            fprintf(stderr, "cp: %s: fchmod failed\n", to.p_path);
++            fprintf(stderr, "cp: %s: fchmod failed: %s\n", to.p_path, strerror(errno));
 +            // warn("%s: fchmod failed", to.p_path);
  #ifdef __APPLE__
  	/* do these before setfile in case copyfile changes mtime */
  	if (!Xflag && S_ISREG(fs->st_mode)) { /* skip devices, etc */
  		if (fcopyfile(from_fd, to_fd, NULL, COPYFILE_XATTR) < 0)
 -			warn("%s: could not copy extended attributes to %s", entp->fts_path, to.p_path);
-+            fprintf(stderr, "cp: %s: could not copy extended attributes to %s\n", entp->fts_path, to.p_path);
++            fprintf(stderr, "cp: %s: could not copy extended attributes to %s: %s\n", entp->fts_path, to.p_path, strerror(errno));
 +            // warn("%s: could not copy extended attributes to %s", entp->fts_path, to.p_path);
  	}
 -	if (pflag && setfile(fs, to_fd))
@@ -1927,7 +1933,7 @@ diff -Naur file_cmds-272/cp/utils.c file_cmds/cp/utils.c
  		/* If this ACL denies writeattr then setfile will fail... */
  		if (fcopyfile(from_fd, to_fd, NULL, COPYFILE_ACL) < 0)
 -			warn("%s: could not copy ACL to %s", entp->fts_path, to.p_path);
-+            fprintf(stderr, "cp: %s: could not copy ACL to %s\n", entp->fts_path, to.p_path);
++            fprintf(stderr, "cp: %s: could not copy ACL to %s: %s\n", entp->fts_path, to.p_path, strerror(errno));
 +            // warn("%s: could not copy ACL to %s", entp->fts_path, to.p_path);
  	}
  #else  /* !__APPLE__ */
@@ -1941,7 +1947,7 @@ diff -Naur file_cmds-272/cp/utils.c file_cmds/cp/utils.c
  	(void)close(from_fd);
  	if (close(to_fd)) {
 -		warn("%s", to.p_path);
-+        fprintf(stderr, "cp: %s\n", to.p_path);
++        fprintf(stderr, "cp: %s: %s\n", to.p_path, strerror(errno));
 +        // warn("%s", to.p_path);
  		rval = 1;
  	}
@@ -1951,20 +1957,20 @@ diff -Naur file_cmds-272/cp/utils.c file_cmds/cp/utils.c
  
  	if ((len = readlink(p->fts_path, llink, sizeof(llink) - 1)) == -1) {
 -		warn("readlink: %s", p->fts_path);
-+        fprintf(stderr, "cp: readlink: %s\n", p->fts_path);
++        fprintf(stderr, "cp: readlink: %s: %s\n", p->fts_path, strerror(errno));
 +        // warn("readlink: %s", p->fts_path);
  		return (1);
  	}
  	llink[len] = '\0';
  	if (exists && unlink(to.p_path)) {
 -		warn("unlink: %s", to.p_path);
-+		fprintf(stderr, "cp: unlink: %s\n", to.p_path);
++        fprintf(stderr, "cp: unlink: %s: %s\n", to.p_path, strerror(errno));
 +        // warn("unlink: %s", to.p_path);
  		return (1);
  	}
  	if (symlink(llink, to.p_path)) {
 -		warn("symlink: %s", llink);
-+		fprintf(stderr, "cp: symlink: %s\n", llink);
++        fprintf(stderr, "cp: symlink: %s: %s\n", llink, strerror(errno));
 +        // warn("symlink: %s", llink);
  		return (1);
  	}
@@ -1972,9 +1978,10 @@ diff -Naur file_cmds-272/cp/utils.c file_cmds/cp/utils.c
  	if (!Xflag)
  		if (copyfile(p->fts_path, to.p_path, NULL, COPYFILE_XATTR | COPYFILE_NOFOLLOW_SRC) <0)
 -			warn("%s: could not copy extended attributes to %s",
+-			     p->fts_path, to.p_path);
 +            // warn("%s: could not copy extended attributes to %s",
-+			fprintf(stderr, "cp: %s: could not copy extended attributes to %s\n",
- 			     p->fts_path, to.p_path);
++            fprintf(stderr, "cp: %s: could not copy extended attributes to %s: %s\n",
++			     p->fts_path, to.p_path, strerror(errno));
  #endif
 -	return (pflag ? setfile(p->fts_statp, -1) : 0);
 +	return (cp_pflag ? setfile(p->fts_statp, -1) : 0);
@@ -1985,13 +1992,13 @@ diff -Naur file_cmds-272/cp/utils.c file_cmds/cp/utils.c
  {
  	if (exists && unlink(to.p_path)) {
 -		warn("unlink: %s", to.p_path);
-+        fprintf(stderr, "cp: unlink: %s\n", to.p_path);
++        fprintf(stderr, "cp: unlink: %s: %s\n", to.p_path, strerror(errno));
 +        // warn("unlink: %s", to.p_path);
  		return (1);
  	}
  	if (mkfifo(to.p_path, from_stat->st_mode)) {
 -		warn("mkfifo: %s", to.p_path);
-+		fprintf(stderr, "cp: mkfifo: %s\n", to.p_path);
++        fprintf(stderr, "cp: mkfifo: %s: %s\n", to.p_path, strerror(errno));
 +        // warn("mkfifo: %s", to.p_path);
  		return (1);
  	}
@@ -2004,13 +2011,13 @@ diff -Naur file_cmds-272/cp/utils.c file_cmds/cp/utils.c
  {
  	if (exists && unlink(to.p_path)) {
 -		warn("unlink: %s", to.p_path);
-+		fprintf(stderr, "cp: unlink: %s\n", to.p_path);
++        fprintf(stderr, "cp: unlink: %s: %s\n", to.p_path, strerror(errno));
 +        // warn("unlink: %s", to.p_path);
  		return (1);
  	}
  	if (mknod(to.p_path, from_stat->st_mode, from_stat->st_rdev)) {
 -		warn("mknod: %s", to.p_path);
-+		fprintf(stderr, "cp: mknod: %s\n", to.p_path);
++        fprintf(stderr, "cp: mknod: %s: %s\n", to.p_path, strerror(errno));
 +        // warn("mknod: %s", to.p_path);
  		return (1);
  	}
@@ -2024,7 +2031,7 @@ diff -Naur file_cmds-272/cp/utils.c file_cmds/cp/utils.c
  	TIMESPEC_TO_TIMEVAL(&tv[1], &fs->st_mtimespec);
  	if (fdval ? futimes(fd, tv) : (islink ? lutimes(to.p_path, tv) : utimes(to.p_path, tv))) {
 -		warn("%sutimes: %s", fdval ? "f" : (islink ? "l" : ""), to.p_path);
-+        fprintf(stderr, "cp: %sutimes: %s\n", fdval ? "f" : (islink ? "l" : ""), to.p_path);
++        fprintf(stderr, "cp: %sutimes: %s: %s\n", fdval ? "f" : (islink ? "l" : ""), to.p_path, strerror(errno));
 +        // warn("%sutimes: %s", fdval ? "f" : (islink ? "l" : ""), to.p_path);
  		rval = 1;
  	}
@@ -2034,7 +2041,7 @@ diff -Naur file_cmds-272/cp/utils.c file_cmds/cp/utils.c
  								  chown(to.p_path, fs->st_uid, fs->st_gid))) {
  			    if (errno != EPERM) {
 -				    warn("%schown: %s", fdval ? "f" : (islink ? "l" : ""), to.p_path);
-+                    fprintf(stderr, "cp: %schown: %s\n", fdval ? "f" : (islink ? "l" : ""), to.p_path);
++                    fprintf(stderr, "cp: %schown: %s: %s\n", fdval ? "f" : (islink ? "l" : ""), to.p_path, strerror(errno));
 +                    // warn("%schown: %s", fdval ? "f" : (islink ? "l" : ""), to.p_path);
  				    rval = 1;
  			    }
@@ -2044,7 +2051,7 @@ diff -Naur file_cmds-272/cp/utils.c file_cmds/cp/utils.c
  						       lchmod(to.p_path, fs->st_mode) :
  						       chmod(to.p_path, fs->st_mode))) {
 -			warn("%schmod: %s", fdval ? "f" : (islink ? "l" : ""), to.p_path);
-+            fprintf(stderr, "cp: %schmod: %s\n", fdval ? "f" : (islink ? "l" : ""), to.p_path);
++            fprintf(stderr, "cp: %schmod: %s: %s\n", fdval ? "f" : (islink ? "l" : ""), to.p_path, strerror(errno));
 +            // warn("%schmod: %s", fdval ? "f" : (islink ? "l" : ""), to.p_path);
  			rval = 1;
  		}
@@ -2054,7 +2061,7 @@ diff -Naur file_cmds-272/cp/utils.c file_cmds/cp/utils.c
  							  chflags(to.p_path, fs->st_flags))) {
  			if (errno != EPERM) {
 -				warn("%schflags: %s", fdval ? "f" : (islink ? "l" : ""), to.p_path);
-+                fprintf(stderr, "cp: %schflags: %s\n", fdval ? "f" : (islink ? "l" : ""), to.p_path);
++                fprintf(stderr, "cp: %schflags: %s: %s\n", fdval ? "f" : (islink ? "l" : ""), to.p_path, strerror(errno));
 +                // warn("%schflags: %s", fdval ? "f" : (islink ? "l" : ""), to.p_path);
  				rval = 1;
  			}
@@ -2064,7 +2071,7 @@ diff -Naur file_cmds-272/cp/utils.c file_cmds/cp/utils.c
  	acl = acl_get_fd(source_fd);
  	if (acl == NULL) {
 -		warn("failed to get acl entries while setting %s", to.p_path);
-+        fprintf(stderr, "cp: failed to get acl entries while setting %s\n", to.p_path);
++        fprintf(stderr, "cp: failed to get acl entries while setting %s: %s\n", to.p_path, strerror(errno));
 +        // warn("failed to get acl entries while setting %s", to.p_path);
  		return (1);
  	}
@@ -2073,7 +2080,7 @@ diff -Naur file_cmds-272/cp/utils.c file_cmds/cp/utils.c
  		return (0);
  	if (acl_set_fd(dest_fd, acl) < 0) {
 -		warn("failed to set acl entries for %s", to.p_path);
-+        fprintf(stderr, "cp: failed to set acl entries for %s\n", to.p_path);
++        fprintf(stderr, "cp: failed to set acl entries for %s: %s\n", to.p_path, strerror(errno));
 +        // warn("failed to set acl entries for %s", to.p_path);
  		return (1);
  	}
@@ -2083,31 +2090,33 @@ diff -Naur file_cmds-272/cp/utils.c file_cmds/cp/utils.c
  	acl = aclgetf(source_dir, ACL_TYPE_DEFAULT);
  	if (acl == NULL) {
 -		warn("failed to get default acl entries on %s",
+-		    source_dir);
 +		// warn("failed to get default acl entries on %s",
-+        fprintf(stderr, "cp: failed to get default acl entries on %s\n",
- 		    source_dir);
++        fprintf(stderr, "cp: failed to get default acl entries on %s: %s\n",
++		    source_dir, strerror(errno));
  		return (1);
  	}
  	aclp = &acl->ats_acl;
  	if (aclp->acl_cnt != 0 && aclsetf(dest_dir,
  	    ACL_TYPE_DEFAULT, acl) < 0) {
 -		warn("failed to set default acl entries on %s",
+-		    dest_dir);
 +        // warn("failed to set default acl entries on %s",
-+        fprintf(stderr, "cp: failed to set default acl entries on %s\n",
- 		    dest_dir);
++        fprintf(stderr, "cp: failed to set default acl entries on %s: %s\n",
++		    dest_dir, strerror(errno));
  		return (1);
  	}
  	acl = aclgetf(source_dir, ACL_TYPE_ACCESS);
  	if (acl == NULL) {
 -		warn("failed to get acl entries on %s", source_dir);
-+        fprintf(stderr, "cp: failed to get acl entries on %s\n", source_dir);
++        fprintf(stderr, "cp: failed to get acl entries on %s: %s\n", source_dir, strerror(errno));
 +        // warn("failed to get acl entries on %s", source_dir);
  		return (1);
  	}
  	aclp = &acl->ats_acl;
  	if (aclsetf(dest_dir, ACL_TYPE_ACCESS, acl) < 0) {
 -		warn("failed to set acl entries on %s", dest_dir);
-+        fprintf(stderr, "cp: failed to set acl entries on %s\n", dest_dir);
++        fprintf(stderr, "cp: failed to set acl entries on %s: %s\n", dest_dir, strerror(errno));
 +        // warn("failed to set acl entries on %s", dest_dir);
  		return (1);
  	}
@@ -2123,7 +2132,7 @@ diff -Naur file_cmds-272/cp/utils.c file_cmds/cp/utils.c
  	if (COMPAT_MODE("bin/cp", "unix2003")) {
 diff -Naur file_cmds-272/df/df.c file_cmds/df/df.c
 --- file_cmds-272/df/df.c	2015-05-13 02:57:59.000000000 +0200
-+++ file_cmds/df/df.c	2017-12-12 23:58:22.000000000 +0100
++++ file_cmds/df/df.c	2018-01-10 11:30:57.000000000 +0100
 @@ -61,7 +61,7 @@
  #include <sys/stat.h>
  #include <sys/mount.h>
@@ -2265,14 +2274,14 @@ diff -Naur file_cmds-272/df/df.c file_cmds/df/df.c
  		if (stat(*argv, &stbuf) < 0) {
  			if ((mntpt = getmntpt(*argv)) == 0) {
 -				warn("%s", *argv);
-+                fprintf(stderr, "df: %s\n", *argv);
++                fprintf(stderr, "df: %s: %s\n", *argv, strerror(errno));
 +                // warn("%s", *argv);
  				rv = 1;
  				continue;
  			}
  		} else if (S_ISCHR(stbuf.st_mode) || S_ISBLK(stbuf.st_mode)) {
 -			warnx("%s: Raw devices not supported", *argv);
-+            fprintf(stderr, "df: %s: Raw devices not supported\n", *argv);
++            fprintf(stderr, "df: %s: Raw devices not supported: %s\n", *argv, strerror(errno));
 +            // warnx("%s: Raw devices not supported", *argv);
  			rv = 1;
  			continue;
@@ -2282,7 +2291,7 @@ diff -Naur file_cmds-272/df/df.c file_cmds/df/df.c
  		 */
  		if (statfs(mntpt, &statfsbuf) < 0) {
 -			warn("%s", mntpt);
-+            fprintf(stderr, "df: %s\n", mntpt);
++            fprintf(stderr, "df: %s: %s\n", mntpt, strerror(errno));
 +            // warn("%s", mntpt);
  			rv = 1;
  			continue;
@@ -2311,14 +2320,14 @@ diff -Naur file_cmds-272/df/df.c file_cmds/df/df.c
  	if (sysctl(mib, 3,
  	    &maxvfsconf, &miblen, NULL, 0)) {
 -		warn("sysctl failed");
-+        fprintf(stderr, "df: sysctl failed\n");
++        fprintf(stderr, "df: sysctl failed: %s\n", strerror(errno));
 +        // warn("sysctl failed");
  		return (NULL);
  	}
  
  	if ((listptr = malloc(sizeof(char*) * maxvfsconf)) == NULL) {
 -		warnx("malloc failed");
-+        fprintf(stderr, "df: malloc failed\n");
++        fprintf(stderr, "df: malloc failed: %s\n", strerror(errno));
 +        // warnx("malloc failed");
  		return (NULL);
  	}
@@ -2328,7 +2337,7 @@ diff -Naur file_cmds-272/df/df.c file_cmds/df/df.c
  			listptr[cnt++] = strdup(ptr->vfc_name);
  			if (listptr[cnt-1] == NULL) {
 -				warnx("malloc failed");
-+                fprintf(stderr, "df: malloc failed\n");
++                fprintf(stderr, "df: malloc failed: %s\n", strerror(errno));
 +				// warnx("malloc failed");
  				return (NULL);
  			}
@@ -2338,7 +2347,7 @@ diff -Naur file_cmds-272/df/df.c file_cmds/df/df.c
  	                        if (listptr[cnt-1] == NULL) {
  					free(listptr);
 -	                                warnx("malloc failed");
-+                                    fprintf(stderr, "df: malloc failed\n");
++                                fprintf(stderr, "df: malloc failed: %s\n", strerror(errno));
 +	                                // warnx("malloc failed");
  	                                return (NULL);
  	                        }
@@ -2348,15 +2357,15 @@ diff -Naur file_cmds-272/df/df.c file_cmds/df/df.c
  	    (str = malloc(sizeof(char) * (32 * cnt + cnt + 2))) == NULL) {
  		if (cnt > 0)
 -			warnx("malloc failed");
-+            fprintf(stderr, "df: malloc failed\n");
++            fprintf(stderr, "df: malloc failed: %s\n", strerror(errno));
 +			// warnx("malloc failed");
  		free(listptr);
  		return (NULL);
  	}
 diff -Naur file_cmds-272/df/vfslist.c file_cmds/df/vfslist.c
 --- file_cmds-272/df/vfslist.c	2013-10-05 00:39:00.000000000 +0200
-+++ file_cmds/df/vfslist.c	2017-12-12 23:58:22.000000000 +0100
-@@ -40,9 +40,11 @@
++++ file_cmds/df/vfslist.c	2018-01-10 11:30:57.000000000 +0100
+@@ -40,9 +40,12 @@
    "$FreeBSD: src/sbin/mount/vfslist.c,v 1.4 1999/08/28 00:13:27 peter Exp $";
  #endif /* not lint */
  
@@ -2365,23 +2374,24 @@ diff -Naur file_cmds-272/df/vfslist.c file_cmds/df/vfslist.c
  #include <stdlib.h>
  #include <string.h>
 +#include <stdio.h>
++#include <errno.h>
 +#include "ios_error.h"
  
  #ifndef __APPLE__
  #include "extern.h"
-@@ -88,7 +90,8 @@
+@@ -88,7 +91,8 @@
  		if (*cnextcp == ',')
  			i++;
  	if ((av = malloc((size_t)(i + 2) * sizeof(char *))) == NULL) {
 -		warnx("malloc failed");
-+        fprintf(stderr, "df: malloc failed\n");
++        fprintf(stderr, "df: malloc failed: %s\n", strerror(errno));
 +        // warnx("malloc failed");
  		return (NULL);
  	}
  	nextcp = strdup(fslist);
 diff -Naur file_cmds-272/du/du.c file_cmds/du/du.c
 --- file_cmds-272/du/du.c	2013-10-05 00:39:00.000000000 +0200
-+++ file_cmds/du/du.c	2017-12-12 23:58:22.000000000 +0100
++++ file_cmds/du/du.c	2018-01-10 11:30:57.000000000 +0100
 @@ -55,7 +55,7 @@
  #include <sys/stat.h>
  #include <sys/attr.h>
@@ -2470,7 +2480,7 @@ diff -Naur file_cmds-272/du/du.c file_cmds/du/du.c
 -		err(1, "fts_open");
 +    if ((fts = fts_open(argv, ftsoptions, NULL)) == NULL) {
 +		// err(1, "fts_open");
-+        fprintf(stderr, "du: fts_open\n");
++        fprintf(stderr, "du: fts_open: %s\n", strerror(errno));
 +        pthread_exit(NULL);
 +    }
  
@@ -2514,7 +2524,7 @@ diff -Naur file_cmds-272/du/du.c file_cmds/du/du.c
 -		err(1, "fts_read");
 +    if (errno) {
 +		// err(1, "fts_read");
-+        fprintf(stderr, "du: fts_read\n");
++        fprintf(stderr, "du: fts_read: %s\n", strerror(errno));
 +        pthread_exit(NULL);
 +    }
  
@@ -2612,7 +2622,7 @@ diff -Naur file_cmds-272/du/du.c file_cmds/du/du.c
  
 diff -Naur file_cmds-272/gzip/gzip.c file_cmds/gzip/gzip.c
 --- file_cmds-272/gzip/gzip.c	2016-07-29 20:21:04.000000000 +0200
-+++ file_cmds/gzip/gzip.c	2017-12-12 23:58:35.000000000 +0100
++++ file_cmds/gzip/gzip.c	2018-01-10 11:30:57.000000000 +0100
 @@ -68,9 +68,14 @@
  #ifdef __APPLE__
  #include <sys/attr.h>
@@ -2882,13 +2892,13 @@ diff -Naur file_cmds-272/gzip/gzip.c file_cmds/gzip/gzip.c
  	if (fts == NULL) {
 -		warn("couldn't fts_open %s", dir);
 +		// warn("couldn't fts_open %s", dir);
-+        fprintf(stderr, "gzip: couldn't fts_open %s\n", dir);
++        fprintf(stderr, "gzip: couldn't fts_open %s: %s\n", dir, strerror(errno));
  		return;
  	}
  
 diff -Naur file_cmds-272/ln/ln.c file_cmds/ln/ln.c
 --- file_cmds-272/ln/ln.c	2013-10-31 01:07:31.000000000 +0100
-+++ file_cmds/ln/ln.c	2017-12-12 23:58:22.000000000 +0100
++++ file_cmds/ln/ln.c	2018-01-10 11:30:57.000000000 +0100
 @@ -44,7 +44,7 @@
  #include <sys/param.h>
  #include <sys/stat.h>
@@ -2974,12 +2984,12 @@ diff -Naur file_cmds-272/ln/ln.c file_cmds/ln/ln.c
 -	if (stat(sourcedir, &sb))
 -		err(1, "%s", sourcedir);
 +		// err(1, "%s", sourcedir);
-+        fprintf(stderr, "ln: %s\n", sourcedir);
++        fprintf(stderr, "ln: %s: %s\n", sourcedir, strerror(errno));
 +        pthread_exit(NULL);
 +	}
 +    if (stat(sourcedir, &sb)) {
 +		// err(1, "%s", sourcedir);
-+        fprintf(stderr, "ln: %s\n", sourcedir);
++        fprintf(stderr, "ln: %s: %s\n", sourcedir, strerror(errno));
 +        pthread_exit(NULL);
 +    }
  	if (!S_ISDIR(sb.st_mode))
@@ -2999,7 +3009,7 @@ diff -Naur file_cmds-272/ln/ln.c file_cmds/ln/ln.c
  		/* If target doesn't exist, quit now. */
  		if (stat(target, &sb)) {
 -			warn("%s", target);
-+            fprintf(stderr, "ln: %s\n", target);
++            fprintf(stderr, "ln: %s: %s\n", target, strerror(errno));
 +            // warn("%s", target);
  			return (1);
  		}
@@ -3007,7 +3017,7 @@ diff -Naur file_cmds-272/ln/ln.c file_cmds/ln/ln.c
  		if (S_ISDIR(sb.st_mode)) {
  			errno = EISDIR;
 -			warn("%s", target);
-+            fprintf(stderr, "ln: %s\n", target);
++            fprintf(stderr, "ln: %s: %s\n", target, strerror(errno));
 +			// warn("%s", target);
  			return (1);
  		}
@@ -3017,7 +3027,7 @@ diff -Naur file_cmds-272/ln/ln.c file_cmds/ln/ln.c
  		    (ssize_t)sizeof(path)) {
  			errno = ENAMETOOLONG;
 -			warn("%s", target);
-+            fprintf(stderr, "ln: %s\n", target);
++            fprintf(stderr, "ln: %s: %s\n", target, strerror(errno));
 +			// warn("%s", target);
  			return (1);
  		}
@@ -3027,13 +3037,13 @@ diff -Naur file_cmds-272/ln/ln.c file_cmds/ln/ln.c
  		if (Fflag && S_ISDIR(sb.st_mode)) {
  			if (rmdir(source)) {
 -				warn("%s", source);
-+                fprintf(stderr, "ln: %s\n", source);
++                fprintf(stderr, "ln: %s: %s\n", source, strerror(errno));
 +				// warn("%s", source);
  				return (1);
  			}
  		} else if (unlink(source)) {
 -			warn("%s", source);
-+            fprintf(stderr, "ln: %s\n", source);
++            fprintf(stderr, "ln: %s: %s\n", source, strerror(errno));
 +			// warn("%s", source);
  			return (1);
  		}
@@ -3043,13 +3053,13 @@ diff -Naur file_cmds-272/ln/ln.c file_cmds/ln/ln.c
  		if (Fflag && S_ISDIR(sb.st_mode)) {
  			if (rmdir(source)) {
 -				warn("%s", source);
-+                fprintf(stderr, "ln: %s\n", source);
++                fprintf(stderr, "ln: %s: %s\n", source, strerror(errno));
 +				// warn("%s", source);
  				return (1);
  			}
  		} else if (unlink(source)) {
 -			warn("%s", source);
-+            fprintf(stderr, "ln: %s\n", source);
++            fprintf(stderr, "ln: %s: %s\n", source, strerror(errno));
 +			// warn("%s", source);
  			return (1);
  		}
@@ -3058,7 +3068,7 @@ diff -Naur file_cmds-272/ln/ln.c file_cmds/ln/ln.c
  	/* Attempt the link. */
  	if ((*linkf)(target, source)) {
 -		warn("%s", source);
-+        fprintf(stderr, "ln: %s\n", source);
++        fprintf(stderr, "ln: %s: %s\n", source, strerror(errno));
 +		// warn("%s", source);
  		return (1);
  	}
@@ -3074,7 +3084,7 @@ diff -Naur file_cmds-272/ln/ln.c file_cmds/ln/ln.c
  	(void)fprintf(stderr, "%s\n%s\n%s\n",
 diff -Naur file_cmds-272/ls/extern.h file_cmds/ls/extern.h
 --- file_cmds-272/ls/extern.h	2010-05-13 01:09:37.000000000 +0200
-+++ file_cmds/ls/extern.h	2017-12-09 00:12:38.000000000 +0100
++++ file_cmds/ls/extern.h	2018-01-10 11:30:57.000000000 +0100
 @@ -51,7 +51,7 @@
  void	 printlong(DISPLAY *);
  void	 printscol(DISPLAY *);
@@ -3086,7 +3096,7 @@ diff -Naur file_cmds-272/ls/extern.h file_cmds/ls/extern.h
  int	 prn_octal(const char *);
 diff -Naur file_cmds-272/ls/ls.c file_cmds/ls/ls.c
 --- file_cmds-272/ls/ls.c	2014-07-04 00:38:26.000000000 +0200
-+++ file_cmds/ls/ls.c	2017-12-12 23:58:22.000000000 +0100
++++ file_cmds/ls/ls.c	2018-01-10 11:30:57.000000000 +0100
 @@ -54,7 +54,7 @@
  #include <sys/ioctl.h>
  
@@ -3229,7 +3239,7 @@ diff -Naur file_cmds-272/ls/ls.c file_cmds/ls/ls.c
 -		err(1, "fts_open");
 +         fts_open(argv, options, f_nosort ? NULL : mastercmp)) == NULL) {
 +		// err(1, "fts_open");
-+        fprintf(stderr, "ls: fts_open\n");
++        fprintf(stderr, "ls: fts_open: %s\n", strerror(errno));
 +        pthread_exit(NULL);
 +    }
  
@@ -3271,7 +3281,7 @@ diff -Naur file_cmds-272/ls/ls.c file_cmds/ls/ls.c
 -	if (errno)
 -		err(1, "fts_read");
 +    if (errno) {
-+        fprintf(stderr, "ls: fts_read\n");
++        fprintf(stderr, "ls: fts_read: %s\n", strerror(errno));
 +        pthread_exit(NULL);
 +		// err(1, "fts_read");
 +    }
@@ -3285,7 +3295,7 @@ diff -Naur file_cmds-272/ls/ls.c file_cmds/ls/ls.c
 -		if (jinitmax == NULL)
 -			err(1, "malloc");
 +        if (jinitmax == NULL) {
-+			fprintf(stderr, "ls: malloc\n");
++            fprintf(stderr, "ls: malloc: %s\n", strerror((errno)));
 +            pthread_exit(NULL);
 +            // err(1, "malloc");
 +        }
@@ -3310,7 +3320,7 @@ diff -Naur file_cmds-272/ls/ls.c file_cmds/ls/ls.c
 -					if (flags == NULL)
 -						err(1, "fflagstostr");
 +                    if (flags == NULL) {
-+						fprintf(stderr, "ls: fflagstostr\n");
++                        fprintf(stderr, "ls: fflagstostr: %s\n", strerror(errno));
 +                        pthread_exit(NULL);
 +                        // err(1, "fflagstostr");
 +                    }
@@ -3323,7 +3333,7 @@ diff -Naur file_cmds-272/ls/ls.c file_cmds/ls/ls.c
  				    ulen + glen + flen + 4)) == NULL)
 -					err(1, "malloc");
 +                {
-+                    fprintf(stderr, "ls: malloc\n");
++                    fprintf(stderr, "ls: malloc: %s\n", strerror(errno));
 +                    // err(1, "malloc");
 +                    pthread_exit(NULL);
 +                }
@@ -3332,7 +3342,7 @@ diff -Naur file_cmds-272/ls/ls.c file_cmds/ls/ls.c
  				(void)strcpy(np->user, user);
 diff -Naur file_cmds-272/ls/print.c file_cmds/ls/print.c
 --- file_cmds-272/ls/print.c	2016-09-28 00:43:20.000000000 +0200
-+++ file_cmds/ls/print.c	2017-12-12 23:58:22.000000000 +0100
++++ file_cmds/ls/print.c	2018-01-10 11:30:57.000000000 +0100
 @@ -56,7 +56,7 @@
  #include <uuid/uuid.h>
  #endif
@@ -3365,7 +3375,7 @@ diff -Naur file_cmds-272/ls/print.c file_cmds/ls/print.c
  	
  	if (NULL == name) {
 -		err(1, "malloc");
-+        fprintf(stderr, "ls: malloc\n");
++        fprintf(stderr, "ls: malloc: %s\n", strerror(errno));
 +        pthread_exit(NULL);
 +        // err(1, "malloc");
  	}
@@ -3377,7 +3387,7 @@ diff -Naur file_cmds-272/ls/print.c file_cmds/ls/print.c
  		if ((array = realloc(array, dp->entries * sizeof(FTSENT *))) == NULL) {
 -			warn(NULL);
 +			// warn(NULL);
-+            fprintf(stderr, "\n");
++            fprintf(stderr, "%s\n", strerror(errno));
  			printscol(dp);
  			return;
  		}
@@ -3393,7 +3403,7 @@ diff -Naur file_cmds-272/ls/print.c file_cmds/ls/print.c
  #endif /* COLORLS */
 diff -Naur file_cmds-272/ls/util.c file_cmds/ls/util.c
 --- file_cmds-272/ls/util.c	2008-03-12 21:31:12.000000000 +0100
-+++ file_cmds/ls/util.c	2017-12-12 23:58:22.000000000 +0100
++++ file_cmds/ls/util.c	2018-01-10 11:30:57.000000000 +0100
 @@ -42,7 +42,7 @@
  #include <sys/stat.h>
  
@@ -3422,7 +3432,7 @@ diff -Naur file_cmds-272/ls/util.c file_cmds/ls/util.c
  #ifdef COLORLS
 diff -Naur file_cmds-272/mkdir/mkdir.c file_cmds/mkdir/mkdir.c
 --- file_cmds-272/mkdir/mkdir.c	2013-10-05 00:39:00.000000000 +0200
-+++ file_cmds/mkdir/mkdir.c	2017-12-12 23:58:22.000000000 +0100
++++ file_cmds/mkdir/mkdir.c	2018-01-10 11:30:57.000000000 +0100
 @@ -49,7 +49,7 @@
  #include <sys/types.h>
  #include <sys/stat.h>
@@ -3477,18 +3487,18 @@ diff -Naur file_cmds-272/mkdir/mkdir.c file_cmds/mkdir/mkdir.c
  			int status = mkpath_np(*argv, omode);
  			if (status && status != EEXIST) {
 -				warnc(status, "%s", *argv);
-+                fprintf(stderr, "mkdir: %s\n", *argv);
++                fprintf(stderr, "mkdir: %s: %s\n", *argv, strerror(errno));
 +                // warnc(status, "%s", *argv);
  				success = 0;
  			}
  		} else if (mkdir(*argv, omode) < 0) {
  			if (errno == ENOTDIR || errno == ENOENT)
 -				warn("%s", dirname(*argv));
-+                fprintf(stderr, "mkdir: %s\n", dirname(*argv));
++                fprintf(stderr, "mkdir: %s: %s\n", dirname(*argv), strerror(errno));
 +				// warn("%s", dirname(*argv));
  			else
 -				warn("%s", *argv);
-+                fprintf(stderr, "mkdir: %s\n", *argv);
++                fprintf(stderr, "mkdir: %s: %s\n", *argv, strerror(errno));
 +				// warn("%s", *argv);
  			success = 0;
  		} else if (vflag)
@@ -3498,14 +3508,14 @@ diff -Naur file_cmds-272/mkdir/mkdir.c file_cmds/mkdir/mkdir.c
  		 */
  		if (success && mode != NULL && chmod(*argv, omode) == -1) {
 -			warn("%s", *argv);
-+            fprintf(stderr, "mkdir: %s\n", *argv);
++            fprintf(stderr, "mkdir: %s: %s\n", *argv, strerror(errno));
 +			// warn("%s", *argv);
  			exitval = 1;
  		}
  	}
 diff -Naur file_cmds-272/mv/mv.c file_cmds/mv/mv.c
 --- file_cmds-272/mv/mv.c	2015-08-04 22:32:26.000000000 +0200
-+++ file_cmds/mv/mv.c	2017-12-12 23:58:22.000000000 +0100
++++ file_cmds/mv/mv.c	2018-01-10 11:30:57.000000000 +0100
 @@ -55,7 +55,7 @@
  #include <sys/stat.h>
  #include <sys/mount.h>
@@ -3620,7 +3630,7 @@ diff -Naur file_cmds-272/mv/mv.c file_cmds/mv/mv.c
  		/* prompt only if source exist */
  	        if (lstat(from, &sb) == -1) {
 -			warn("%s", from);
-+            fprintf(stderr, "mv: %s\n", from);
++                fprintf(stderr, "mv: %s: %s\n", from, strerror(errno));
 +            //warn("%s", from);
  			return (1);
  		}
@@ -3642,7 +3652,7 @@ diff -Naur file_cmds-272/mv/mv.c file_cmds/mv/mv.c
  		}
  	} else {
 -		warn("rename %s to %s", from, to);
-+        fprintf(stderr, "mv: rename %s to %s\n", from, to);
++        fprintf(stderr, "mv: rename %s to %s: %s\n", from, to, strerror(errno));
 +        // warn("rename %s to %s", from, to);
  		return (1);
  	}
@@ -3652,7 +3662,7 @@ diff -Naur file_cmds-272/mv/mv.c file_cmds/mv/mv.c
  	 */
  	if (lstat(from, &sb)) {
 -		warn("%s", from);
-+        fprintf(stderr, "mv: %s\n", from);
++        fprintf(stderr, "mv: %s: %s\n", from, strerror(errno));
 +        // warn("%s", from);
  		return (1);
  	}
@@ -3667,7 +3677,7 @@ diff -Naur file_cmds-272/mv/mv.c file_cmds/mv/mv.c
  
  	if ((from_fd = open(from, O_RDONLY, 0)) < 0) {
 -		warn("%s", from);
-+        fprintf(stderr, "mv: %s\n", from);
++        fprintf(stderr, "mv: %s: %s\n", from, strerror(errno));
 +		// warn("%s", from);
  		return (1);
  	}
@@ -3687,7 +3697,7 @@ diff -Naur file_cmds-272/mv/mv.c file_cmds/mv/mv.c
  		if (errno == EEXIST && unlink(to) == 0)
  			continue;
 -		warn("%s", to);
-+        fprintf(stderr, "mv: %s\n", to);
++        fprintf(stderr, "mv: %s: %s\n", to, strerror(errno));
 +		// warn("%s", to);
  		(void)close(from_fd);
  		return (1);
@@ -3697,39 +3707,41 @@ diff -Naur file_cmds-272/mv/mv.c file_cmds/mv/mv.c
  	while ((nread = read(from_fd, bp, (size_t)blen)) > 0)
  		if (write(to_fd, bp, (size_t)nread) != nread) {
 -			warn("%s", to);
-+            fprintf(stderr, "mv: %s\n", to);
++            fprintf(stderr, "mv: %s: %s\n", to, strerror(errno));
 +			// warn("%s", to);
  			goto err;
  		}
  	if (nread < 0) {
 -		warn("%s", from);
-+        fprintf(stderr, "mv: %s\n", from);
++        fprintf(stderr, "mv: %s: %s\n", from, strerror(errno));
 +		// warn("%s", from);
  err:		if (unlink(to))
 -			warn("%s: remove", to);
-+            fprintf(stderr, "mv: %s: remove\n", to);
++                fprintf(stderr, "mv: %s: remove: %s\n", to, strerror(errno));
 +            // warn("%s: remove", to);
  		(void)close(from_fd);
  		(void)close(to_fd);
  		return (1);
-@@ -387,7 +410,8 @@
+@@ -387,25 +410,29 @@
  #ifdef __APPLE__
  	/* XATTR can fail if to_fd has mode 000 */
  	if (fcopyfile(from_fd, to_fd, NULL, COPYFILE_ACL | COPYFILE_XATTR) < 0) {
 -		warn("%s: unable to move extended attributes and ACL from %s",
+-		     to, from);
 +        // warn("%s: unable to move extended attributes and ACL from %s",
-+        fprintf(stderr, "mv: %s: unable to move extended attributes and ACL from %s\n",
- 		     to, from);
++        fprintf(stderr, "mv: %s: unable to move extended attributes and ACL from %s: %s\n",
++                to, from, strerror(errno));
  	}
  #endif
-@@ -395,17 +419,20 @@
+ 	(void)close(from_fd);
  
  	oldmode = sbp->st_mode & ALLPERMS;
  	if (fchown(to_fd, sbp->st_uid, sbp->st_gid)) {
 -		warn("%s: set owner/group (was: %lu/%lu)", to,
+-		    (u_long)sbp->st_uid, (u_long)sbp->st_gid);
 +        // warn("%s: set owner/group (was: %lu/%lu)", to,
-+        fprintf(stderr, "mv: %s: set owner/group (was: %lu/%lu)\n", to,
- 		    (u_long)sbp->st_uid, (u_long)sbp->st_gid);
++        fprintf(stderr, "mv: %s: set owner/group (was: %lu/%lu): %s\n", to,
++		    (u_long)sbp->st_uid, (u_long)sbp->st_gid, strerror(errno));
  		if (oldmode & (S_ISUID | S_ISGID)) {
 -			warnx(
 -"%s: owner/group changed; clearing suid/sgid (mode was 0%03o)",
@@ -3742,7 +3754,7 @@ diff -Naur file_cmds-272/mv/mv.c file_cmds/mv/mv.c
  	}
  	if (fchmod(to_fd, sbp->st_mode))
 -		warn("%s: set mode (was: 0%03o)", to, oldmode);
-+        fprintf(stderr, "mv: %s: set mode (was: 0%03o)\n", to, oldmode);
++        fprintf(stderr, "mv: %s: set mode (was: 0%03o): %s\n", to, oldmode, strerror(errno));
 +        // warn("%s: set mode (was: 0%03o)", to, oldmode);
  	/*
  	 * XXX
@@ -3752,7 +3764,7 @@ diff -Naur file_cmds-272/mv/mv.c file_cmds/mv/mv.c
  	if (fchflags(to_fd, (u_int)sbp->st_flags))
  		if (errno != ENOTSUP || sbp->st_flags != 0)
 -			warn("%s: set flags (was: 0%07o)", to, sbp->st_flags);
-+            fprintf(stderr, "mv: %s: set flags (was: 0%07o)\n", to, sbp->st_flags);
++            fprintf(stderr, "mv: %s: set flags (was: 0%07o): %s\n", to, sbp->st_flags, strerror(errno));
 +            // warn("%s: set flags (was: 0%07o)", to, sbp->st_flags);
  
  	tval[0].tv_sec = sbp->st_atime;
@@ -3760,7 +3772,7 @@ diff -Naur file_cmds-272/mv/mv.c file_cmds/mv/mv.c
  	tval[0].tv_usec = tval[1].tv_usec = 0;
  	if (utimes(to, tval))
 -		warn("%s: set times", to);
-+        fprintf(stderr, "mv: %s: set times\n", to);
++        fprintf(stderr, "mv: %s: set times: %s\n", to, strerror(errno));
 +        // warn("%s: set times", to);
  
  	if (close(to_fd)) {
@@ -3772,7 +3784,7 @@ diff -Naur file_cmds-272/mv/mv.c file_cmds/mv/mv.c
  
  	if (unlink(from)) {
 -		warn("%s: remove", from);
-+        fprintf(stderr, "mv: %s: remove\n", from);
++        fprintf(stderr, "mv: %s: remove: %s\n", from, strerror(errno));
 +        // warn("%s: remove", from);
  		return (1);
  	}
@@ -3833,7 +3845,7 @@ diff -Naur file_cmds-272/mv/mv.c file_cmds/mv/mv.c
  {
 diff -Naur file_cmds-272/rm/rm.c file_cmds/rm/rm.c
 --- file_cmds-272/rm/rm.c	2016-09-16 18:43:23.000000000 +0200
-+++ file_cmds/rm/rm.c	2017-12-12 23:58:22.000000000 +0100
++++ file_cmds/rm/rm.c	2018-01-10 11:30:57.000000000 +0100
 @@ -51,7 +51,7 @@
  #include <sys/param.h>
  #include <sys/mount.h>
@@ -3899,11 +3911,12 @@ diff -Naur file_cmds-272/rm/rm.c file_cmds/rm/rm.c
  	/*
  	 * Test for the special case where the utility is called as
  	 * "unlink", for which the functionality provided is greatly
-@@ -201,19 +206,23 @@
+@@ -201,19 +206,24 @@
  	if (!(fts = fts_open(argv, flags, NULL))) {
  		if (fflag && errno == ENOENT)
  			return;
 -		err(1, NULL);
++        fprintf(stderr, "rm: %s\n", strerror(errno));
 +        pthread_exit(NULL);
 +		// err(1, NULL);
  	}
@@ -3926,7 +3939,7 @@ diff -Naur file_cmds-272/rm/rm.c file_cmds/rm/rm.c
  		case FTS_NS:
  			/*
  			 * FTS_NS: assume that if can't stat the file, it
-@@ -222,7 +231,8 @@
+@@ -222,7 +232,8 @@
  			if (!needstat)
  				break;
  			if (!fflag || p->fts_errno != ENOENT) {
@@ -3936,12 +3949,12 @@ diff -Naur file_cmds-272/rm/rm.c file_cmds/rm/rm.c
  				    p->fts_path, strerror(p->fts_errno));
  				eval = 1;
  			}
-@@ -320,12 +330,16 @@
+@@ -320,12 +331,16 @@
  			}
  		}
  err:
 -		warn("%s", p->fts_path);
-+        fprintf(stderr, "rm: %s\n", p->fts_path);
++        fprintf(stderr, "rm: %s: %s\n", p->fts_path, strerror(errno));
 +        // warn("%s", p->fts_path);
  		eval = 1;
  	}
@@ -3951,18 +3964,18 @@ diff -Naur file_cmds-272/rm/rm.c file_cmds/rm/rm.c
 +    fts_close(fts);
 +    if (errno) {
 +		// err(1, "fts_read");
-+        fprintf(stderr, "rm: fts_read\n");
++        fprintf(stderr, "rm: fts_read: %s\n", strerror(errno));
 +        pthread_exit(NULL);
 +    }
  }
  
  void
-@@ -347,19 +361,22 @@
+@@ -347,19 +362,22 @@
  				sb.st_mode = S_IFWHT|S_IWUSR|S_IRUSR;
  			} else {
  				if (!fflag || errno != ENOENT) {
 -					warn("%s", f);
-+                    fprintf(stderr, "rm: %s\n", f);
++                    fprintf(stderr, "rm: %s: %s\n", f, strerror(errno));
 +                    // warn("%s", f);
  					eval = 1;
  				}
@@ -3983,17 +3996,17 @@ diff -Naur file_cmds-272/rm/rm.c file_cmds/rm/rm.c
  			eval = 1;
  			continue;
  		}
-@@ -390,7 +407,8 @@
+@@ -390,7 +408,8 @@
  			}
  		}
  		if (rval && (!fflag || errno != ENOENT)) {
 -			warn("%s", f);
-+            fprintf(stderr, "rm: %s\n", f);
++            fprintf(stderr, "rm: %s: %s\n", f, strerror(errno));
 +            // warn("%s", f);
  			eval = 1;
  		}
  		if (vflag && rval == 0)
-@@ -432,8 +450,11 @@
+@@ -432,8 +451,11 @@
  	if (fstatfs(fd, &fsb) == -1)
  		goto err;
  	bsize = MAX(fsb.f_iosize, 1024);
@@ -4001,35 +4014,37 @@ diff -Naur file_cmds-272/rm/rm.c file_cmds/rm/rm.c
 -		err(1, "malloc");
 +    if ((buf = malloc(bsize)) == NULL) {
 +		// err(1, "malloc");
-+        fprintf(stderr, "rm: malloc\n");
++        fprintf(stderr, "rm: malloc: %s\n", strerror(errno));
 +        pthread_exit(NULL);
 +    }
  
  #define	PASS(byte) {							\
  	memset(buf, byte, bsize);					\
-@@ -458,7 +479,8 @@
+@@ -458,7 +480,8 @@
  err:	eval = 1;
  	if (buf)
  		free(buf);
 -	warn("%s", file);
-+        fprintf(stderr, "rm: %s\n", file);
++        fprintf(stderr, "rm: %s: %s\n", file, strerror(errno));
 +    // warn("%s", file);
  }
  
  int 
-@@ -506,8 +528,9 @@
+@@ -506,8 +529,11 @@
  		    (!(sp->st_flags & (UF_APPEND|UF_IMMUTABLE)) || !uid)))
  			return (1);
  		strmode(sp->st_mode, modep);
 -		if ((flagsp = fflagstostr(sp->st_flags)) == NULL)
 -			err(1, NULL);
-+        if ((flagsp = fflagstostr(sp->st_flags)) == NULL)
++        if ((flagsp = fflagstostr(sp->st_flags)) == NULL) {
++            fprintf(stderr, "rm: %s\n", strerror(errno));
 +            pthread_exit(NULL);
 +			// err(1, NULL);
++        }
  		(void)fprintf(stderr, "override %s%s%s/%s %s%sfor %s? ",
  		    modep + 1, modep[9] == ' ' ? "" : " ",
  		    user_from_uid(sp->st_uid, 0),
-@@ -554,7 +577,8 @@
+@@ -554,7 +580,8 @@
  		}
  		if (ISDOT(p)) {
  			if (!complained++)
@@ -4041,7 +4056,7 @@ diff -Naur file_cmds-272/rm/rm.c file_cmds/rm/rm.c
  				continue;
 diff -Naur file_cmds-272/rmdir/rmdir.c file_cmds/rmdir/rmdir.c
 --- file_cmds-272/rmdir/rmdir.c	2013-10-05 00:39:00.000000000 +0200
-+++ file_cmds/rmdir/rmdir.c	2017-12-12 23:58:22.000000000 +0100
++++ file_cmds/rmdir/rmdir.c	2018-01-10 11:30:57.000000000 +0100
 @@ -46,23 +46,26 @@
  #include <sys/cdefs.h>
  __RCSID("$FreeBSD: src/bin/rmdir/rmdir.c,v 1.13 2002/06/30 05:15:03 obrien Exp $");
@@ -4078,7 +4093,7 @@ diff -Naur file_cmds-272/rmdir/rmdir.c file_cmds/rmdir/rmdir.c
  	for (errors = 0; *argv; argv++) {
  		if (rmdir(*argv) < 0) {
 -			warn("%s", *argv);
-+            fprintf(stderr, "rmdir: %s\n", *argv);
++            fprintf(stderr, "rmdir: %s: %s\n", *argv, strerror(errno));
 +            // warn("%s", *argv);
  			errors = 1;
  		} else if (pflag)
@@ -4088,14 +4103,14 @@ diff -Naur file_cmds-272/rmdir/rmdir.c file_cmds/rmdir/rmdir.c
  
  		if (rmdir(path) < 0) {
 -			warn("%s", path);
-+            fprintf(stderr, "rmdir: %s\n", path);
++            fprintf(stderr, "rmdir: %s: %s\n", path, strerror(errno));
 +            // warn("%s", path);
  			return (1);
  		}
  	}
 diff -Naur file_cmds-272/stat/stat.c file_cmds/stat/stat.c
 --- file_cmds-272/stat/stat.c	2014-02-11 01:17:24.000000000 +0100
-+++ file_cmds/stat/stat.c	2017-12-12 23:58:22.000000000 +0100
++++ file_cmds/stat/stat.c	2018-01-10 11:30:57.000000000 +0100
 @@ -58,7 +58,7 @@
  #include <sys/stat.h>
  
@@ -4105,15 +4120,16 @@ diff -Naur file_cmds-272/stat/stat.c file_cmds/stat/stat.c
  #include <grp.h>
  #include <limits.h>
  #include <pwd.h>
-@@ -67,6 +67,7 @@
+@@ -67,6 +67,8 @@
  #include <string.h>
  #include <time.h>
  #include <unistd.h>
++#include <errno.h>
 +#include "ios_error.h"
  
  #if HAVE_STRUCT_STAT_ST_FLAGS
  #define DEF_F "%#Xf "
-@@ -180,18 +181,18 @@
+@@ -180,18 +182,18 @@
  #define SHOW_filename	'N'
  #define SHOW_sizerdev	'Z'
  
@@ -4137,7 +4153,7 @@ diff -Naur file_cmds-272/stat/stat.c file_cmds/stat/stat.c
  
  #define addchar(s, c, nl) \
  	do { \
-@@ -199,8 +200,10 @@
+@@ -199,8 +201,10 @@
  		(*nl) = ((c) == '\n'); \
  	} while (0/*CONSTCOND*/)
  
@@ -4149,7 +4165,7 @@ diff -Naur file_cmds-272/stat/stat.c file_cmds/stat/stat.c
  {
  	struct stat st;
  	int ch, rc, errs, am_readlink;
-@@ -216,8 +219,11 @@
+@@ -216,8 +220,11 @@
  	linkfail = 0;
  	statfmt = NULL;
  	timefmt = NULL;
@@ -4162,7 +4178,7 @@ diff -Naur file_cmds-272/stat/stat.c file_cmds/stat/stat.c
  		am_readlink = 1;
  		options = "n";
  		synopsis = "[-n] [file ...]";
-@@ -250,9 +256,12 @@
+@@ -250,9 +257,12 @@
  		case 'r':
  		case 's':
  		case 'x':
@@ -4177,7 +4193,7 @@ diff -Naur file_cmds-272/stat/stat.c file_cmds/stat/stat.c
  			fmtchar = ch;
  			break;
  		case 't':
-@@ -275,8 +284,11 @@
+@@ -275,8 +285,11 @@
  		}
  	}
  
@@ -4191,17 +4207,19 @@ diff -Naur file_cmds-272/stat/stat.c file_cmds/stat/stat.c
  
  	switch (fmtchar) {
  	case 'f':
-@@ -317,7 +329,8 @@
+@@ -317,8 +330,9 @@
  			errs = 1;
  			linkfail = 1;
  			if (!quiet)
 -				warn("%s: stat",
+-				    argc == 0 ? "(stdin)" : argv[0]);
 +				// warn("%s: stat",
-+                fprintf(stderr, "star: %s: stat\n",
- 				    argc == 0 ? "(stdin)" : argv[0]);
++                fprintf(stderr, "stat: %s: stat: %s\n",
++				    argc == 0 ? "(stdin)" : argv[0], strerror(errno));
  		}
  		else
-@@ -334,8 +347,8 @@
+ 			output(&st, argv[0], statfmt, fn, nonl, quiet);
+@@ -334,8 +348,8 @@
  void
  usage(const char *synopsis)
  {
@@ -4212,7 +4230,7 @@ diff -Naur file_cmds-272/stat/stat.c file_cmds/stat/stat.c
  	exit(1);
  }
  
-@@ -523,8 +536,10 @@
+@@ -523,8 +537,10 @@
  		continue;
  
  	badfmt:
@@ -4224,7 +4242,7 @@ diff -Naur file_cmds-272/stat/stat.c file_cmds/stat/stat.c
  	}
  
  	if (!nl && !nonl)
-@@ -858,15 +873,20 @@
+@@ -858,15 +874,20 @@
  		}
  		/*NOTREACHED*/
  	default:
@@ -4248,7 +4266,7 @@ diff -Naur file_cmds-272/stat/stat.c file_cmds/stat/stat.c
  
  	/*
  	 * Assemble the format string for passing to printf(3).
-@@ -969,8 +989,11 @@
+@@ -969,8 +990,11 @@
  	 * String output uses the temporary sdata.
  	 */
  	if (ofmt == FMTF_STRING) {
@@ -4264,7 +4282,7 @@ diff -Naur file_cmds-272/stat/stat.c file_cmds/stat/stat.c
  	}
 diff -Naur file_cmds-272/touch/touch.c file_cmds/touch/touch.c
 --- file_cmds-272/touch/touch.c	2013-10-05 00:39:00.000000000 +0200
-+++ file_cmds/touch/touch.c	2017-12-12 23:58:22.000000000 +0100
++++ file_cmds/touch/touch.c	2018-01-10 11:30:57.000000000 +0100
 @@ -49,7 +49,7 @@
  #include <sys/stat.h>
  #include <sys/time.h>
@@ -4310,7 +4328,7 @@ diff -Naur file_cmds-272/touch/touch.c file_cmds/touch/touch.c
 -		err(1, "gettimeofday");
 +    if (gettimeofday(&tv[0], NULL)) {
 +		// err(1, "gettimeofday");
-+        fprintf(stderr, "touch: gettimeofday\n");
++        fprintf(stderr, "touch: gettimeofday: %s\n", strerror(errno));
 +        pthread_exit(NULL);
 +    }
  
@@ -4321,7 +4339,7 @@ diff -Naur file_cmds-272/touch/touch.c file_cmds/touch/touch.c
  			if (errno != ENOENT) {
  				rval = 1;
 -				warn("%s", *argv);
-+                fprintf(stderr, "touch: %s\n", *argv);
++                fprintf(stderr, "touch: %s: %s\n", *argv, strerror(errno));
 +                // warn("%s", *argv);
  				continue;
  			}
@@ -4331,7 +4349,7 @@ diff -Naur file_cmds-272/touch/touch.c file_cmds/touch/touch.c
  				if (fd == -1 || fstat(fd, &sb) || close(fd)) {
  					rval = 1;
 -					warn("%s", *argv);
-+					fprintf(stderr, "touch: %s\n", *argv);
++                    fprintf(stderr, "touch: %s: %s\n", *argv, strerror(errno));
 +                    // warn("%s", *argv);
  					continue;
  				}
@@ -4341,7 +4359,7 @@ diff -Naur file_cmds-272/touch/touch.c file_cmds/touch/touch.c
  		if (timeset || Aflag) {
  			rval = 1;
 -			warn("%s", *argv);
-+            fprintf(stderr, "touch: %s\n", *argv);
++            fprintf(stderr, "touch: %s: %s\n", *argv, strerror(errno));
 +            // warn("%s", *argv);
  			continue;
  		}
@@ -4351,7 +4369,7 @@ diff -Naur file_cmds-272/touch/touch.c file_cmds/touch/touch.c
  		} else {
  			rval = 1;
 -			warn("%s", *argv);
-+            fprintf(stderr, "touch: %s\n", *argv);
++            fprintf(stderr, "touch: %s: %s\n", *argv, strerror(errno));
 +            // warn("%s", *argv);
  		}
  	}
@@ -4364,7 +4382,7 @@ diff -Naur file_cmds-272/touch/touch.c file_cmds/touch/touch.c
 -		err(1, "localtime");
 +    if ((t = localtime(&now)) == NULL) {
 +		// err(1, "localtime");
-+        fprintf(stderr, "touch: localtime\n");
++        fprintf(stderr, "touch: localtime: %s\n", strerror(errno));
 +        pthread_exit(NULL);
 +    }
  					/* [[CC]YY]MMDDhhmm[.SS] */
@@ -4391,7 +4409,7 @@ diff -Naur file_cmds-272/touch/touch.c file_cmds/touch/touch.c
 -		err(1, "localtime");
 +    if ((t = localtime(&now)) == NULL) {
 +		// err(1, "localtime");
-+        fprintf(stderr, "touch: localtime\n");
++        fprintf(stderr, "touch: localtime: %s\n", strerror(errno));
 +        pthread_exit(NULL);
 +    }
  
@@ -4432,7 +4450,7 @@ diff -Naur file_cmds-272/touch/touch.c file_cmds/touch/touch.c
 -		err(1, "%s", fname);
 +    if (stat(fname, &sb)) {
 +		// err(1, "%s", fname);
-+        fprintf(stderr, "touch: %s\n", fname);
++        fprintf(stderr, "touch: %s: %s\n", fname, strerror(errno));
 +        pthread_exit(NULL);
 +    }
  	TIMESPEC_TO_TIMEVAL(tvp, &sb.st_atimespec);
@@ -4453,12 +4471,12 @@ diff -Naur file_cmds-272/touch/touch.c file_cmds/touch/touch.c
  		if (write(fd, &byte, sizeof(byte)) != sizeof(byte)) {
  err:			rval = 1;
 -			warn("%s", fname);
-+            fprintf(stderr, "touch: %s\n", fname);
++            fprintf(stderr, "touch: %s: %s\n", fname, strerror(errno));
 +            // warn("%s", fname);
  		} else if (ftruncate(fd, (off_t)0)) {
  			rval = 1;
 -			warn("%s: file modified", fname);
-+			fprintf(stderr, "touch: %s: file modified\n", fname);
++            fprintf(stderr, "touch: %s: file modified: %s\n", fname, strerror(errno));
 +            // warn("%s: file modified", fname);
  		}
  	}
@@ -4472,7 +4490,7 @@ diff -Naur file_cmds-272/touch/touch.c file_cmds/touch/touch.c
  	if (needed_chmod && chmod(fname, sbp->st_mode) && rval != 1) {
  		rval = 1;
 -		warn("%s: permissions modified", fname);
-+		fprintf(stderr, "touch: %s: permissions modified\n", fname);
++        fprintf(stderr, "touch: %s: permissions modified: %s\n", fname, strerror(errno));
 +        // warn("%s: permissions modified", fname);
  	}
  	return (rval);

--- a/Dependencies/ios_system/file_cmds/chflags/chflags.c
+++ b/Dependencies/ios_system/file_cmds/chflags/chflags.c
@@ -137,7 +137,7 @@ chflags_main(int argc, char *argv[])
 			errno = ERANGE;
         if (errno) {
             // err(1, "invalid flags: %s", flags);
-            fprintf(stderr, "chflags: invalid flags: %s\n", flags);
+            fprintf(stderr, "chflags: %s: invalid flags: %s\n", flags, strerror(errno));
             pthread_exit(NULL);
         }
         if (*ep) {
@@ -159,6 +159,7 @@ chflags_main(int argc, char *argv[])
 
     if ((ftsp = fts_open(++argv, fts_options , 0)) == NULL) {
 		// err(1, NULL);
+        fprintf(stderr, "chflags: %s\n", strerror(errno));
         pthread_exit(NULL);
     }
 
@@ -200,7 +201,7 @@ chflags_main(int argc, char *argv[])
 			continue;
 		if ((*change_flags)(p->fts_accpath, (u_int)newflags) && !fflag) {
 			// warn("%s", p->fts_path);
-            fprintf(stderr,"chflags: %s\n", p->fts_path);
+            fprintf(stderr,"chflags: %s: %s\n", p->fts_path, strerror(errno));
 			rval = 1;
 		} else if (vflag) {
 			(void)printf("%s", p->fts_path);
@@ -213,7 +214,7 @@ chflags_main(int argc, char *argv[])
 	}
     if (errno) {
 		// err(1, "fts_read");
-        fprintf(stderr, "chflags: fts_read\n");
+        fprintf(stderr, "chflags: fts_read: %s\n", strerror(errno));
         pthread_exit(NULL);
     }
 	exit(rval);

--- a/Dependencies/ios_system/file_cmds/chmod/chmod.c
+++ b/Dependencies/ios_system/file_cmds/chmod/chmod.c
@@ -314,7 +314,7 @@ apnoacl:
 		
         if (mode == NULL) {
 			// err(1, "Unable to allocate mode string");
-            fprintf(stderr, "chmod: Unable to allocate mode string\n");
+            fprintf(stderr, "chmod: Unable to allocate mode string: %s\n", strerror(errno));
             pthread_exit(NULL);
         }
 		/* Read the ACEs from STDIN */
@@ -367,7 +367,7 @@ apnoacl:
 				errno = ERANGE;
             if (errno) {
 				// err(1, "Invalid file mode: %s", mode);
-                fprintf(stderr, "chmod: Invalid file mode: %s\n", mode);
+                fprintf(stderr, "chmod: Invalid file mode: %s: %s\n", mode, strerror(errno));
                 pthread_exit(NULL);
             }
             if (*ep) {
@@ -390,7 +390,7 @@ apnoacl:
 #endif /* __APPLE__*/
     if ((ftsp = fts_open(++argv, fts_options, 0)) == NULL) {
 		// err(1, "fts_open");
-        fprintf(stderr, "chmod: fts_open\n");
+        fprintf(stderr, "chmod: fts_open: %s\n", strerror(errno));
         pthread_exit(NULL);
     }
 	for (rval = 0; (p = fts_read(ftsp)) != NULL;) {
@@ -440,7 +440,7 @@ apnoacl:
 			if ((newmode & ALLPERMS) == (p->fts_statp->st_mode & ALLPERMS))
 				continue;
 			if ((*change_mode)(p->fts_accpath, newmode) && !chmod_fflag) {
-                fprintf(stderr, "chmod: Unable to change file mode on %s\n", p->fts_path);
+                fprintf(stderr, "chmod: Unable to change file mode on %s: %s\n", p->fts_path, strerror(errno));
                 // warn("Unable to change file mode on %s", p->fts_path);
 				rval = 1;
 			} else {
@@ -469,7 +469,7 @@ apnoacl:
 	}
     if (errno) {
 		// err(1, "fts_read");
-        fprintf(stderr, "chmod: fts_read\n");
+        fprintf(stderr, "chmod: fts_read: %s\n", strerror(errno));
         pthread_exit(NULL);
     }
 #ifdef __APPLE__

--- a/Dependencies/ios_system/file_cmds/chmod/chmod_acl.c
+++ b/Dependencies/ios_system/file_cmds/chmod/chmod_acl.c
@@ -248,7 +248,7 @@ parse_acl_entries(const char *input) {
 	
     if (inbuf == NULL) {
 		// err(1, "malloc() failed");
-        fprintf(stderr, "chmod: malloc() failed\n");
+        fprintf(stderr, "chmod: malloc() failed: %s\n", strerror(errno));
         pthread_exit(NULL);
     }
 	strncpy(inbuf, input, MAX_ACL_TEXT_SIZE);
@@ -256,7 +256,7 @@ parse_acl_entries(const char *input) {
 
     if ((acl_input = acl_init(1)) == NULL) {
 		// err(1, "acl_init() failed");
-        fprintf(stderr, "chmod: acl_init() failed\n");
+        fprintf(stderr, "chmod: acl_init() failed: %s\n", strerror(errno));
         pthread_exit(NULL);
     }
 
@@ -266,7 +266,7 @@ parse_acl_entries(const char *input) {
 		if (**bufp != '\0') {
             if (0 != acl_create_entry(&acl_input, &newent)) {
 				// err(1, "acl_create_entry() failed");
-                fprintf(stderr, "chmod: acl_create_entry() failed\n");
+                fprintf(stderr, "chmod: acl_create_entry() failed: %s\n", strerror(errno));
                 pthread_exit(NULL);
             }
 			if (0 != parse_entry(*bufp, newent)) {
@@ -312,17 +312,17 @@ score_acl_entry(acl_entry_t entry) {
 
 	if (acl_get_tag_type(entry, &tag) != 0) {
 		// err(1, "Malformed ACL entry, no tag present");
-        fprintf(stderr, "chmod: Malformed ACL entry, no tag present\n");
+        fprintf(stderr, "chmod: Malformed ACL entry, no tag present: %s\n", strerror(errno));
         pthread_exit(NULL);
 	}
 	if (acl_get_flagset_np(entry, &flags) != 0){
 		// err(1, "Unable to obtain flagset");
-        fprintf(stderr, "chmod: Unable to obtain flagset\n");
+        fprintf(stderr, "chmod: Unable to obtain flagset: %s\n", strerror(errno));
         pthread_exit(NULL);
 	}
     if (acl_get_permset(entry, &perms) != 0) {
 		// err(1, "Malformed ACL entry, no permt present");
-        fprintf(stderr, "chmod: Malformed ACL entry, no permt present\n");
+        fprintf(stderr, "chmod: Malformed ACL entry, no permt present: %s\n", strerror(errno));
         pthread_exit(NULL);
     }
 	
@@ -407,12 +407,12 @@ compare_acl_entries(acl_entry_t a, acl_entry_t b)
 
     if (0 != acl_get_tag_type(a, &atag)) {
 		// err(1, "No tag type present in entry");
-        fprintf(stderr, "chmod: No tag type present in entry\n");
+        fprintf(stderr, "chmod: No tag type present in entry: %s\n", strerror(errno));
         pthread_exit(NULL);
     }
     if (0!= acl_get_tag_type(b, &btag)) {
 		// err(1, "No tag type present in entry");
-        fprintf(stderr, "chmod: No tag type present in entry\n");
+        fprintf(stderr, "chmod: No tag type present in entry: %s\n", strerror(errno));
         pthread_exit(NULL);
     }
 
@@ -424,7 +424,7 @@ compare_acl_entries(acl_entry_t a, acl_entry_t b)
 	    (acl_get_permset(b, &bperms) != 0) ||
         (acl_get_flagset_np(b, &bflags) != 0)) {
 		// err(1, "error fetching permissions");
-        fprintf(stderr, "chmod: error fetching permissions\n");
+        fprintf(stderr, "chmod: error fetching permissions: %s\n", strerror(errno));
         pthread_exit(NULL);
     }
 
@@ -527,13 +527,13 @@ find_matching_entry (acl_t acl, acl_entry_t modifier, acl_entry_t *rentryp,
 
                 if (0 != acl_get_flagset_np(modifier, &mflags)) {
 					// err(1, "Unable to get flagset");
-                    fprintf(stderr, "chmod: Unable to get flagset\n");
+                    fprintf(stderr, "chmod: Unable to get flagset: %s\n", strerror(errno));
                     pthread_exit(NULL);
                 }
 				
                 if (0 != acl_get_flagset_np(entry, &eflags)) {
 					// err(1, "Unable to get flagset");
-                    fprintf(stderr, "chmod: Unable to get flagset\n");
+                    fprintf(stderr, "chmod: Unable to get flagset: %s\n", strerror(errno));
                     pthread_exit(NULL);
                 }
 					
@@ -568,7 +568,7 @@ subtract_from_entry(acl_entry_t rentry, acl_entry_t  modifier, int* valid_perms)
 	    (acl_get_permset(modifier, &mperms) != 0) ||
         (acl_get_flagset_np(modifier, &mflags) != 0)) {
 		// err(1, "error computing ACL modification");
-        fprintf(stderr, "chmod: error computing ACL modification\n");
+        fprintf(stderr, "chmod: error computing ACL modification: %s\n", strerror(errno));
         pthread_exit(NULL);
     }
 
@@ -599,7 +599,7 @@ merge_entry_perms(acl_entry_t rentry, acl_entry_t  modifier)
 	    (acl_get_permset(modifier, &mperms) != 0) ||
         (acl_get_flagset_np(modifier, &mflags) != 0)) {
 		// err(1, "error computing ACL modification");
-        fprintf(stderr, "chmod: error computing ACL modification\n");
+        fprintf(stderr, "chmod: error computing ACL modification: %s\n", strerror(errno));
         pthread_exit(NULL);
     }
 
@@ -641,7 +641,7 @@ modify_acl(acl_t *oaclp, acl_entry_t modifier, unsigned int optflags,
 		if (position != -1) {
             if (0 != acl_create_entry_np(&oacl, &newent, position)) {
 				// err(1, "acl_create_entry() failed");
-                fprintf(stderr, "chmod: acl_create_entry() failed\n");
+                fprintf(stderr, "chmod: acl_create_entry() failed: %s\n", strerror(errno));
                 pthread_exit(NULL);
             }
 			acl_copy_entry(newent, modifier);
@@ -667,7 +667,7 @@ modify_acl(acl_t *oaclp, acl_entry_t modifier, unsigned int optflags,
 			cpos = find_canonical_position(oacl, modifier);
             if (0!= acl_create_entry_np(&oacl, &newent, cpos)) {
 				// err(1, "acl_create_entry() failed");
-                fprintf(stderr, "chmod: acl_create_entry() failed\n");
+                fprintf(stderr, "chmod: acl_create_entry() failed: %s\n", strerror(errno));
                 pthread_exit(NULL);
             }
 			acl_copy_entry(newent, modifier);
@@ -726,19 +726,19 @@ modify_acl(acl_t *oaclp, acl_entry_t modifier, unsigned int optflags,
 			if (0 != acl_get_entry(oacl, position,
                             &rentry)) {
 				// err(1, "Invalid entry number '%s'", path);
-                fprintf(stderr, "chmod: Invalid entry number '%s'\n", path);
+                fprintf(stderr, "chmod: Invalid entry number '%s': %s\n", path, strerror(errno));
                 pthread_exit(NULL);
             }
 			
             if (0 != acl_delete_entry(oacl, rentry)) {
 				// err(1, "Unable to delete entry '%s'", path);
-                fprintf(stderr, "chmod: Unable to delete entry '%s'\n", path);
+                fprintf(stderr, "chmod: Unable to delete entry '%s': %s\n", path, strerror(errno));
                 pthread_exit(NULL);
             }
 		}
         if (0!= acl_create_entry_np(&oacl, &newent, position)) {
 			// err(1, "acl_create_entry() failed");
-            fprintf(stderr, "chmod: acl_create_entry() failed\n");
+            fprintf(stderr, "chmod: acl_create_entry() failed: %s\n", strerror(errno));
             pthread_exit(NULL);
         }
 		acl_copy_entry(newent, modifier);
@@ -780,19 +780,19 @@ modify_file_acl(unsigned int optflags, const char *path, acl_t modifier, int pos
 		filesec_t fsec = filesec_init();
 		if (fsec == NULL) {
 			// err(1, "filesec_init() failed");
-            fprintf(stderr, "chmod: filesec_init() failed\n");
+            fprintf(stderr, "chmod: filesec_init() failed: %s\n", strerror(errno));
             pthread_exit(NULL);
 		}
 		if (filesec_set_property(fsec, FILESEC_ACL, _FILESEC_REMOVE_ACL) != 0) {
             // err(1, "filesec_set_property() failed");
-			fprintf(stderr, "chmod: filesec_set_property() failed\n");
+            fprintf(stderr, "chmod: filesec_set_property() failed: %s\n", strerror(errno));
             pthread_exit(NULL);
                 }
 		if (follow) {
 			if (chmodx_np(path, fsec) != 0) {
-                                if (!chmod_fflag) {
+                if (!chmod_fflag) {
 					// warn("Failed to clear ACL on file %s", path);
-                    fprintf(stderr, "chmod: Failed to clear ACL on file %s\n", path);
+                    fprintf(stderr, "chmod: Failed to clear ACL on file %s: %s\n", path, strerror(errno));
 				}
 				retval = 1;
 			}
@@ -801,7 +801,7 @@ modify_file_acl(unsigned int optflags, const char *path, acl_t modifier, int pos
 			if (fd != -1) {
 				if (fchmodx_np(fd, fsec) != 0) {
 					if (!chmod_fflag) {
-                        fprintf(stderr, "chmod: Failed to clear ACL on file %s\n", path);
+                        fprintf(stderr, "chmod: Failed to clear ACL on file %s: %s\n", path, strerror(errno));
                         // warn("Failed to clear ACL on file %s", path);
 					}
 					retval = 1;
@@ -810,7 +810,7 @@ modify_file_acl(unsigned int optflags, const char *path, acl_t modifier, int pos
 			} else {
 				if (!chmod_fflag) {
 					// warn("Failed to open file %s", path);
-                    fprintf(stderr, "chmod: Failed to open file %s\n", path);
+                    fprintf(stderr, "chmod: Failed to open file %s: %s\n", path, strerror(errno));
 				}
 				retval = 1;
 			}
@@ -835,7 +835,7 @@ modify_file_acl(unsigned int optflags, const char *path, acl_t modifier, int pos
 		    (acl_get_entry(oacl,ACL_FIRST_ENTRY, &newent) != 0)) {
             if ((oacl = acl_init(1)) == NULL) {
 				// err(1, "acl_init() failed");
-                fprintf(stderr, "chmod: acl_init() failed\n");
+                fprintf(stderr, "chmod: acl_init() failed: %s\n", strerror(errno));
                 pthread_exit(NULL);
             }
 			flag_new_acl = 1;
@@ -847,7 +847,7 @@ modify_file_acl(unsigned int optflags, const char *path, acl_t modifier, int pos
 			acl_t facl = NULL;
             if ((facl = acl_init(1)) == NULL) {
 				//err(1, "acl_init() failed");
-                fprintf(stderr, "chmod: acl_init() failed\n");
+                fprintf(stderr, "chmod: acl_init() failed: %s\n", strerror(errno));
                 pthread_exit(NULL);
             }
 			for (aindex = 0; 
@@ -858,7 +858,7 @@ modify_file_acl(unsigned int optflags, const char *path, acl_t modifier, int pos
 				acl_flagset_t eflags;
 				acl_entry_t fent = NULL;
 				if (acl_get_flagset_np(entry, &eflags) != 0) {
-                    fprintf(stderr,  "chmod: Unable to obtain flagset\n");
+                    fprintf(stderr,  "chmod: Unable to obtain flagset: %s\n", strerror(errno));
                     pthread_exit(NULL);
                     // err(1, "Unable to obtain flagset");
 				}
@@ -944,7 +944,7 @@ modify_file_acl(unsigned int optflags, const char *path, acl_t modifier, int pos
 		}
 		if (status != 0) {
 			if (!chmod_fflag)
-                fprintf(stderr, "chmod: Failed to set ACL on file '%s'\n", path);
+                fprintf(stderr, "chmod: Failed to set ACL on file '%s': %s\n", path, strerror(errno));
             // warn("Failed to set ACL on file '%s'", path);
 			retval = 1;
 		}

--- a/Dependencies/ios_system/file_cmds/chown/chown.c
+++ b/Dependencies/ios_system/file_cmds/chown/chown.c
@@ -176,9 +176,11 @@ chown_main(int argc, char **argv)
 		a_gid(*argv);
 	}
 
-	if ((ftsp = fts_open(++argv, fts_options, 0)) == NULL)
+    if ((ftsp = fts_open(++argv, fts_options, 0)) == NULL) {
+        fprintf(stderr, "chown: %s\n", strerror(errno));
         pthread_exit(NULL);
         //err(1, NULL);
+    }
 
 	for (rval = 0; (p = fts_read(ftsp)) != NULL;) {
 		symlink_found = 0;
@@ -246,7 +248,7 @@ chown_main(int argc, char **argv)
 	}
 	if (errno)
 		//err(1, "fts_read");
-        fprintf(stderr, "chown: fts_read\n");
+        fprintf(stderr, "chown: fts_read: %s\n", strerror(errno));
 	exit(rval);
 }
 
@@ -298,7 +300,7 @@ chownerr(const char *file)
 	if (errno != EPERM || (uid != (uid_t)-1 &&
 	    euid == (uid_t)-1 && (euid = geteuid()) != 0)) {
 		// warn("%s", file);
-        fprintf(stderr, "chown: %s\n", file);
+        fprintf(stderr, "chown: %s: %s\n", file, strerror(errno));
 		return;
 	}
 
@@ -314,7 +316,7 @@ chownerr(const char *file)
 		}
 	}
 	// warn("%s", file);
-    fprintf(stderr, "chown: %s\n", file);
+    fprintf(stderr, "chown: %s: %s\n", file, strerror(errno));
 }
 
 void

--- a/Dependencies/ios_system/file_cmds/cksum/cksum.c
+++ b/Dependencies/ios_system/file_cmds/cksum/cksum.c
@@ -61,6 +61,7 @@ __FBSDID("$FreeBSD: src/usr.bin/cksum/cksum.c,v 1.17 2003/03/13 23:32:28 robert 
 #include <unistd.h>
 
 #include "extern.h"
+#include <errno.h>
 #include "ios_error.h" // remap exit to pthread_exit
 
 static void usage(void);
@@ -127,14 +128,14 @@ chksum_main(int argc, char **argv)
 		if (*argv) {
 			fn = *argv++;
 			if ((fd = open(fn, O_RDONLY, 0)) < 0) {
-                fprintf(stderr, "chksum: %s\n", fn);
+                fprintf(stderr, "chksum: %s: %s\n", fn, strerror(errno));
                 // warn("%s", fn);
 				rval = 1;
 				continue;
 			}
 		}
 		if (cfncn(fd, &val, &len)) {
-            fprintf(stderr, "chksum: %s\n", fn ? fn : "stdin");
+            fprintf(stderr, "chksum: %s: %s\n", fn ? fn : "stdin", strerror(errno));
             // warn("%s", fn ? fn : "stdin");
 			rval = 1;
 		} else

--- a/Dependencies/ios_system/file_cmds/cp/cp.c
+++ b/Dependencies/ios_system/file_cmds/cp/cp.c
@@ -259,7 +259,7 @@ cp_main(int argc, char *argv[])
 	r = stat(to.p_path, &to_stat);
     if (r == -1 && errno != ENOENT) {
 		// err(1, "%s", to.p_path);
-        fprintf(stderr, "cp: %s\n", to.p_path);
+        fprintf(stderr, "cp: %s: %s\n", to.p_path, strerror(errno));
         pthread_exit(NULL);
     }
 	if (r == -1 || !S_ISDIR(to_stat.st_mode)) {
@@ -332,7 +332,7 @@ copy(char *argv[], enum op type, int fts_options)
 
     if ((ftsp = fts_open(argv, fts_options, NULL)) == NULL) {
 		// err(1, "fts_open");
-        fprintf(stderr, "cp: fts_open\n");
+        fprintf(stderr, "cp: fts_open: %s\n", strerror(errno));
         pthread_exit(NULL);
     }
 	for (badcp = rval = 0; (curr = fts_read(ftsp)) != NULL; badcp = 0) {
@@ -463,7 +463,7 @@ copy(char *argv[], enum op type, int fts_options)
 				/* setfile will fail if writeattr is denied */
 				if (copyfile(curr->fts_path, to.p_path, NULL, COPYFILE_ACL)<0)
 					// warn("%s: unable to copy ACL to %s", curr->fts_path, to.p_path);
-                    fprintf(stderr, "cp: %s: unable to copy ACL to %s\n", curr->fts_path, to.p_path);
+                    fprintf(stderr, "cp: %s: unable to copy ACL to %s: %s\n", curr->fts_path, to.p_path, strerror(errno));
 #else  /* !__APPLE__ */
 				if (preserve_dir_acls(curr->fts_statp,
 				    curr->fts_accpath, to.p_path) != 0)
@@ -475,7 +475,7 @@ copy(char *argv[], enum op type, int fts_options)
 				    ((mode | S_IRWXU) & mask) != (mode & mask))
 					if (chmod(to.p_path, mode & mask) != 0){
 						// warn("chmod: %s", to.p_path);
-                        fprintf(stderr, "cp: chmod: %s\n", to.p_path);
+                        fprintf(stderr, "cp: chmod: %s: %s\n", to.p_path, strerror(errno));
 						rval = 1;
 					}
 			}
@@ -542,11 +542,11 @@ copy(char *argv[], enum op type, int fts_options)
 				if (mkdir(to.p_path,
 					  curr->fts_statp->st_mode | S_IRWXU) < 0) {
 					if (COMPAT_MODE("bin/cp", "unix2003")) {
-                        fprintf(stderr, "cp: %s\n", to.p_path);
+                        fprintf(stderr, "cp: %s: %s\n", to.p_path, strerror(errno));
                         // warn("%s", to.p_path);
 					} else {
 						// err(1, "%s", to.p_path);
-                        fprintf(stderr, "cp: %s\n", to.p_path);
+                        fprintf(stderr, "cp: %s: %s\n", to.p_path, strerror(errno));
                         pthread_exit(NULL);
 					}
 				}
@@ -554,10 +554,10 @@ copy(char *argv[], enum op type, int fts_options)
 				errno = ENOTDIR;
 				if (COMPAT_MODE("bin/cp", "unix2003")) {
 					// warn("%s", to.p_path);
-                    fprintf(stderr, "cp: %s\n", to.p_path);
+                    fprintf(stderr, "cp: %s: %s\n", to.p_path, strerror(errno));
 				} else {
 					// err(1, "%s", to.p_path);
-                    fprintf(stderr, "cp: %s\n", to.p_path);
+                    fprintf(stderr, "cp: %s: %s\n", to.p_path, strerror(errno));
                     pthread_exit(NULL);
 				}
 			}
@@ -570,7 +570,7 @@ copy(char *argv[], enum op type, int fts_options)
 #ifdef __APPLE__
 			if (!Xflag) {
 				if (copyfile(curr->fts_path, to.p_path, NULL, COPYFILE_XATTR) < 0)
-                    fprintf(stderr, "cp: %s: unable to copy extended attributes to %s\n", curr->fts_path, to.p_path);
+                    fprintf(stderr, "cp: %s: unable to copy extended attributes to %s: %s\n", curr->fts_path, to.p_path, strerror(errno));
                 // warn("%s: unable to copy extended attributes to %s", curr->fts_path, to.p_path);
 				/* ACL and mtime set in postorder traversal */
 			}
@@ -605,7 +605,7 @@ copy(char *argv[], enum op type, int fts_options)
 	}
     fts_close(ftsp);
     if (errno) {
-        fprintf(stderr, "cp: fts_read\n");
+        fprintf(stderr, "cp: fts_read: %s\n", strerror(errno));
         pthread_exit(NULL);
 		// err(1, "fts_read");
     }

--- a/Dependencies/ios_system/file_cmds/cp/utils.c
+++ b/Dependencies/ios_system/file_cmds/cp/utils.c
@@ -87,7 +87,7 @@ copy_file(const FTSENT *entp, int dne)
 	struct stat to_stat;
 
 	if ((from_fd = open(entp->fts_path, O_RDONLY, 0)) == -1) {
-        fprintf(stderr, "cp: %s\n", entp->fts_path);
+        fprintf(stderr, "cp: %s: %s\n", entp->fts_path, strerror(errno));
         // warn("%s", entp->fts_path);
 		return (1);
 	}
@@ -126,7 +126,7 @@ copy_file(const FTSENT *entp, int dne)
 			(void)unlink(to.p_path);
 			int error = clonefile(entp->fts_path, to.p_path, 0);
 			if (error)
-                fprintf(stderr, "cp: %s: clonefile failed\n", to.p_path);
+                fprintf(stderr, "cp: %s: clonefile failed: %s\n", to.p_path, strerror(errno));
             // warn("%s: clonefile failed", to.p_path);
 			(void)close(from_fd);
 			return error == 0 ? 0 : 1;
@@ -159,7 +159,7 @@ copy_file(const FTSENT *entp, int dne)
 		if (cp_cflag) {
 			int error = clonefile(entp->fts_path, to.p_path, 0);
 			if (error)
-                fprintf(stderr, "cp: %s: clonefile failed\n", to.p_path);
+                fprintf(stderr, "cp: %s: clonefile failed: %s\n", to.p_path, strerror(errno));
             //  warn("%s: clonefile failed", to.p_path);
 			(void)close(from_fd);
 			return error == 0 ? 0 : 1;
@@ -170,7 +170,7 @@ copy_file(const FTSENT *entp, int dne)
 	}
 
 	if (to_fd == -1) {
-        fprintf(stderr, "cp: %s\n", to.p_path);
+        fprintf(stderr, "cp: %s: %s\n", to.p_path, strerror(errno));
         // warn("%s", to.p_path);
 		(void)close(from_fd);
 		return (1);
@@ -205,12 +205,12 @@ copy_file(const FTSENT *entp, int dne)
 	       if ((mode & (S_IRWXG|S_IRWXO))
 		   && fchmod(to_fd, mode & ~(S_IRWXG|S_IRWXO))) {
 		       if (errno != EPERM) /* we have write access but do not own the file */
-                   fprintf(stderr, "cp: %s: fchmod failed\n", to.p_path);
+                   fprintf(stderr, "cp: %s: fchmod failed: %s\n", to.p_path, strerror(errno));
                    // warn("%s: fchmod failed", to.p_path);
 		       mode = 0;
 	       }
        } else {
-           fprintf(stderr, "cp: %s\n", to.p_path);
+           fprintf(stderr, "cp: %s: %s\n", to.p_path, strerror(errno));
            // warn("%s", to.p_path);
        }
 	/*
@@ -223,7 +223,7 @@ copy_file(const FTSENT *entp, int dne)
 	    fs->st_size <= 8 * 1048576) {
 		if ((p = mmap(NULL, (size_t)fs->st_size, PROT_READ,
 		    MAP_SHARED, from_fd, (off_t)0)) == MAP_FAILED) {
-            fprintf(stderr, "cp: %s\n", entp->fts_path);
+            fprintf(stderr, "cp: %s: %s\n", entp->fts_path, strerror(errno));
             // warn("%s", entp->fts_path);
 			rval = 1;
 		} else {
@@ -244,13 +244,13 @@ copy_file(const FTSENT *entp, int dne)
 					break;
 			}
 			if (wcount != (ssize_t)wresid) {
-                fprintf(stderr, "cp: %s\n", to.p_path);
+                fprintf(stderr, "cp: %s: %s\n", to.p_path, strerror(errno));
                 // warn("%s", to.p_path);
 				rval = 1;
 			}
 			/* Some systems don't unmap on close(2). */
 			if (munmap(p, fs->st_size) < 0) {
-                fprintf(stderr, "cp: %s\n", entp->fts_path);
+                fprintf(stderr, "cp: %s: %s\n", entp->fts_path, strerror(errno));
                 // warn("%s", entp->fts_path);
 				rval = 1;
 			}
@@ -276,14 +276,14 @@ copy_file(const FTSENT *entp, int dne)
 					break;
 			}
 			if (wcount != (ssize_t)wresid) {
-                fprintf(stderr, "cp: %s\n", to.p_path);
+                fprintf(stderr, "cp: %s: %s\n", to.p_path, strerror(errno));
                 // warn("%s", to.p_path);
 				rval = 1;
 				break;
 			}
 		}
 		if (rcount < 0) {
-            fprintf(stderr, "cp: %s\n", entp->fts_path);
+            fprintf(stderr, "cp: %s: %s\n", entp->fts_path, strerror(errno));
             // warn("%s", entp->fts_path);
 			rval = 1;
 		}
@@ -297,13 +297,13 @@ copy_file(const FTSENT *entp, int dne)
 	 */
 	if (mode != 0)
 		if (fchmod(to_fd, mode))
-            fprintf(stderr, "cp: %s: fchmod failed\n", to.p_path);
+            fprintf(stderr, "cp: %s: fchmod failed: %s\n", to.p_path, strerror(errno));
             // warn("%s: fchmod failed", to.p_path);
 #ifdef __APPLE__
 	/* do these before setfile in case copyfile changes mtime */
 	if (!Xflag && S_ISREG(fs->st_mode)) { /* skip devices, etc */
 		if (fcopyfile(from_fd, to_fd, NULL, COPYFILE_XATTR) < 0)
-            fprintf(stderr, "cp: %s: could not copy extended attributes to %s\n", entp->fts_path, to.p_path);
+            fprintf(stderr, "cp: %s: could not copy extended attributes to %s: %s\n", entp->fts_path, to.p_path, strerror(errno));
             // warn("%s: could not copy extended attributes to %s", entp->fts_path, to.p_path);
 	}
 	if (cp_pflag && setfile(fs, to_fd))
@@ -311,7 +311,7 @@ copy_file(const FTSENT *entp, int dne)
 	if (cp_pflag) {
 		/* If this ACL denies writeattr then setfile will fail... */
 		if (fcopyfile(from_fd, to_fd, NULL, COPYFILE_ACL) < 0)
-            fprintf(stderr, "cp: %s: could not copy ACL to %s\n", entp->fts_path, to.p_path);
+            fprintf(stderr, "cp: %s: could not copy ACL to %s: %s\n", entp->fts_path, to.p_path, strerror(errno));
             // warn("%s: could not copy ACL to %s", entp->fts_path, to.p_path);
 	}
 #else  /* !__APPLE__ */
@@ -322,7 +322,7 @@ copy_file(const FTSENT *entp, int dne)
 #endif /* __APPLE__ */
 	(void)close(from_fd);
 	if (close(to_fd)) {
-        fprintf(stderr, "cp: %s\n", to.p_path);
+        fprintf(stderr, "cp: %s: %s\n", to.p_path, strerror(errno));
         // warn("%s", to.p_path);
 		rval = 1;
 	}
@@ -336,18 +336,18 @@ copy_link(const FTSENT *p, int exists)
 	char llink[PATH_MAX];
 
 	if ((len = readlink(p->fts_path, llink, sizeof(llink) - 1)) == -1) {
-        fprintf(stderr, "cp: readlink: %s\n", p->fts_path);
+        fprintf(stderr, "cp: readlink: %s: %s\n", p->fts_path, strerror(errno));
         // warn("readlink: %s", p->fts_path);
 		return (1);
 	}
 	llink[len] = '\0';
 	if (exists && unlink(to.p_path)) {
-		fprintf(stderr, "cp: unlink: %s\n", to.p_path);
+        fprintf(stderr, "cp: unlink: %s: %s\n", to.p_path, strerror(errno));
         // warn("unlink: %s", to.p_path);
 		return (1);
 	}
 	if (symlink(llink, to.p_path)) {
-		fprintf(stderr, "cp: symlink: %s\n", llink);
+        fprintf(stderr, "cp: symlink: %s: %s\n", llink, strerror(errno));
         // warn("symlink: %s", llink);
 		return (1);
 	}
@@ -355,8 +355,8 @@ copy_link(const FTSENT *p, int exists)
 	if (!Xflag)
 		if (copyfile(p->fts_path, to.p_path, NULL, COPYFILE_XATTR | COPYFILE_NOFOLLOW_SRC) <0)
             // warn("%s: could not copy extended attributes to %s",
-			fprintf(stderr, "cp: %s: could not copy extended attributes to %s\n",
-			     p->fts_path, to.p_path);
+            fprintf(stderr, "cp: %s: could not copy extended attributes to %s: %s\n",
+			     p->fts_path, to.p_path, strerror(errno));
 #endif
 	return (cp_pflag ? setfile(p->fts_statp, -1) : 0);
 }
@@ -365,12 +365,12 @@ int
 copy_fifo(struct stat *from_stat, int exists)
 {
 	if (exists && unlink(to.p_path)) {
-        fprintf(stderr, "cp: unlink: %s\n", to.p_path);
+        fprintf(stderr, "cp: unlink: %s: %s\n", to.p_path, strerror(errno));
         // warn("unlink: %s", to.p_path);
 		return (1);
 	}
 	if (mkfifo(to.p_path, from_stat->st_mode)) {
-		fprintf(stderr, "cp: mkfifo: %s\n", to.p_path);
+        fprintf(stderr, "cp: mkfifo: %s: %s\n", to.p_path, strerror(errno));
         // warn("mkfifo: %s", to.p_path);
 		return (1);
 	}
@@ -381,12 +381,12 @@ int
 copy_special(struct stat *from_stat, int exists)
 {
 	if (exists && unlink(to.p_path)) {
-		fprintf(stderr, "cp: unlink: %s\n", to.p_path);
+        fprintf(stderr, "cp: unlink: %s: %s\n", to.p_path, strerror(errno));
         // warn("unlink: %s", to.p_path);
 		return (1);
 	}
 	if (mknod(to.p_path, from_stat->st_mode, from_stat->st_rdev)) {
-		fprintf(stderr, "cp: mknod: %s\n", to.p_path);
+        fprintf(stderr, "cp: mknod: %s: %s\n", to.p_path, strerror(errno));
         // warn("mknod: %s", to.p_path);
 		return (1);
 	}
@@ -408,7 +408,7 @@ setfile(struct stat *fs, int fd)
 	TIMESPEC_TO_TIMEVAL(&tv[0], &fs->st_atimespec);
 	TIMESPEC_TO_TIMEVAL(&tv[1], &fs->st_mtimespec);
 	if (fdval ? futimes(fd, tv) : (islink ? lutimes(to.p_path, tv) : utimes(to.p_path, tv))) {
-        fprintf(stderr, "cp: %sutimes: %s\n", fdval ? "f" : (islink ? "l" : ""), to.p_path);
+        fprintf(stderr, "cp: %sutimes: %s: %s\n", fdval ? "f" : (islink ? "l" : ""), to.p_path, strerror(errno));
         // warn("%sutimes: %s", fdval ? "f" : (islink ? "l" : ""), to.p_path);
 		rval = 1;
 	}
@@ -430,7 +430,7 @@ setfile(struct stat *fs, int fd)
 								  lchown(to.p_path, fs->st_uid, fs->st_gid) :
 								  chown(to.p_path, fs->st_uid, fs->st_gid))) {
 			    if (errno != EPERM) {
-                    fprintf(stderr, "cp: %schown: %s\n", fdval ? "f" : (islink ? "l" : ""), to.p_path);
+                    fprintf(stderr, "cp: %schown: %s: %s\n", fdval ? "f" : (islink ? "l" : ""), to.p_path, strerror(errno));
                     // warn("%schown: %s", fdval ? "f" : (islink ? "l" : ""), to.p_path);
 				    rval = 1;
 			    }
@@ -442,7 +442,7 @@ setfile(struct stat *fs, int fd)
 		if (fdval ? fchmod(fd, fs->st_mode) : (islink ?
 						       lchmod(to.p_path, fs->st_mode) :
 						       chmod(to.p_path, fs->st_mode))) {
-            fprintf(stderr, "cp: %schmod: %s\n", fdval ? "f" : (islink ? "l" : ""), to.p_path);
+            fprintf(stderr, "cp: %schmod: %s: %s\n", fdval ? "f" : (islink ? "l" : ""), to.p_path, strerror(errno));
             // warn("%schmod: %s", fdval ? "f" : (islink ? "l" : ""), to.p_path);
 			rval = 1;
 		}
@@ -453,7 +453,7 @@ setfile(struct stat *fs, int fd)
 							  lchflags(to.p_path, fs->st_flags) :
 							  chflags(to.p_path, fs->st_flags))) {
 			if (errno != EPERM) {
-                fprintf(stderr, "cp: %schflags: %s\n", fdval ? "f" : (islink ? "l" : ""), to.p_path);
+                fprintf(stderr, "cp: %schflags: %s: %s\n", fdval ? "f" : (islink ? "l" : ""), to.p_path, strerror(errno));
                 // warn("%schflags: %s", fdval ? "f" : (islink ? "l" : ""), to.p_path);
 				rval = 1;
 			}
@@ -474,7 +474,7 @@ preserve_fd_acls(int source_fd, int dest_fd)
 		return (0);
 	acl = acl_get_fd(source_fd);
 	if (acl == NULL) {
-        fprintf(stderr, "cp: failed to get acl entries while setting %s\n", to.p_path);
+        fprintf(stderr, "cp: failed to get acl entries while setting %s: %s\n", to.p_path, strerror(errno));
         // warn("failed to get acl entries while setting %s", to.p_path);
 		return (1);
 	}
@@ -482,7 +482,7 @@ preserve_fd_acls(int source_fd, int dest_fd)
 	if (aclp->acl_cnt == 3)
 		return (0);
 	if (acl_set_fd(dest_fd, acl) < 0) {
-        fprintf(stderr, "cp: failed to set acl entries for %s\n", to.p_path);
+        fprintf(stderr, "cp: failed to set acl entries for %s: %s\n", to.p_path, strerror(errno));
         // warn("failed to set acl entries for %s", to.p_path);
 		return (1);
 	}
@@ -518,27 +518,27 @@ preserve_dir_acls(struct stat *fs, char *source_dir, char *dest_dir)
 	acl = aclgetf(source_dir, ACL_TYPE_DEFAULT);
 	if (acl == NULL) {
 		// warn("failed to get default acl entries on %s",
-        fprintf(stderr, "cp: failed to get default acl entries on %s\n",
-		    source_dir);
+        fprintf(stderr, "cp: failed to get default acl entries on %s: %s\n",
+		    source_dir, strerror(errno));
 		return (1);
 	}
 	aclp = &acl->ats_acl;
 	if (aclp->acl_cnt != 0 && aclsetf(dest_dir,
 	    ACL_TYPE_DEFAULT, acl) < 0) {
         // warn("failed to set default acl entries on %s",
-        fprintf(stderr, "cp: failed to set default acl entries on %s\n",
-		    dest_dir);
+        fprintf(stderr, "cp: failed to set default acl entries on %s: %s\n",
+		    dest_dir, strerror(errno));
 		return (1);
 	}
 	acl = aclgetf(source_dir, ACL_TYPE_ACCESS);
 	if (acl == NULL) {
-        fprintf(stderr, "cp: failed to get acl entries on %s\n", source_dir);
+        fprintf(stderr, "cp: failed to get acl entries on %s: %s\n", source_dir, strerror(errno));
         // warn("failed to get acl entries on %s", source_dir);
 		return (1);
 	}
 	aclp = &acl->ats_acl;
 	if (aclsetf(dest_dir, ACL_TYPE_ACCESS, acl) < 0) {
-        fprintf(stderr, "cp: failed to set acl entries on %s\n", dest_dir);
+        fprintf(stderr, "cp: failed to set acl entries on %s: %s\n", dest_dir, strerror(errno));
         // warn("failed to set acl entries on %s", dest_dir);
 		return (1);
 	}

--- a/Dependencies/ios_system/file_cmds/df/df.c
+++ b/Dependencies/ios_system/file_cmds/df/df.c
@@ -286,13 +286,13 @@ df_main(int argc, char *argv[])
 	for (; *argv; argv++) {
 		if (stat(*argv, &stbuf) < 0) {
 			if ((mntpt = getmntpt(*argv)) == 0) {
-                fprintf(stderr, "df: %s\n", *argv);
+                fprintf(stderr, "df: %s: %s\n", *argv, strerror(errno));
                 // warn("%s", *argv);
 				rv = 1;
 				continue;
 			}
 		} else if (S_ISCHR(stbuf.st_mode) || S_ISBLK(stbuf.st_mode)) {
-            fprintf(stderr, "df: %s: Raw devices not supported\n", *argv);
+            fprintf(stderr, "df: %s: Raw devices not supported: %s\n", *argv, strerror(errno));
             // warnx("%s: Raw devices not supported", *argv);
 			rv = 1;
 			continue;
@@ -303,7 +303,7 @@ df_main(int argc, char *argv[])
 		 * implement nflag here.
 		 */
 		if (statfs(mntpt, &statfsbuf) < 0) {
-            fprintf(stderr, "df: %s\n", mntpt);
+            fprintf(stderr, "df: %s: %s\n", mntpt, strerror(errno));
             // warn("%s", mntpt);
 			rv = 1;
 			continue;
@@ -602,13 +602,13 @@ makenetvfslist(void)
 	miblen=sizeof(maxvfsconf);
 	if (sysctl(mib, 3,
 	    &maxvfsconf, &miblen, NULL, 0)) {
-        fprintf(stderr, "df: sysctl failed\n");
+        fprintf(stderr, "df: sysctl failed: %s\n", strerror(errno));
         // warn("sysctl failed");
 		return (NULL);
 	}
 
 	if ((listptr = malloc(sizeof(char*) * maxvfsconf)) == NULL) {
-        fprintf(stderr, "df: malloc failed\n");
+        fprintf(stderr, "df: malloc failed: %s\n", strerror(errno));
         // warnx("malloc failed");
 		return (NULL);
 	}
@@ -618,7 +618,7 @@ makenetvfslist(void)
 		if (ptr->vfc_flags & VFCF_NETWORK) {
 			listptr[cnt++] = strdup(ptr->vfc_name);
 			if (listptr[cnt-1] == NULL) {
-                fprintf(stderr, "df: malloc failed\n");
+                fprintf(stderr, "df: malloc failed: %s\n", strerror(errno));
 				// warnx("malloc failed");
 				return (NULL);
 			}
@@ -633,7 +633,7 @@ makenetvfslist(void)
 	                        listptr[cnt++] = strdup(vfc.vfc_name);
 	                        if (listptr[cnt-1] == NULL) {
 					free(listptr);
-                                    fprintf(stderr, "df: malloc failed\n");
+                                fprintf(stderr, "df: malloc failed: %s\n", strerror(errno));
 	                                // warnx("malloc failed");
 	                                return (NULL);
 	                        }
@@ -645,7 +645,7 @@ makenetvfslist(void)
 	if (cnt == 0 ||
 	    (str = malloc(sizeof(char) * (32 * cnt + cnt + 2))) == NULL) {
 		if (cnt > 0)
-            fprintf(stderr, "df: malloc failed\n");
+            fprintf(stderr, "df: malloc failed: %s\n", strerror(errno));
 			// warnx("malloc failed");
 		free(listptr);
 		return (NULL);

--- a/Dependencies/ios_system/file_cmds/df/vfslist.c
+++ b/Dependencies/ios_system/file_cmds/df/vfslist.c
@@ -44,6 +44,7 @@ __used static const char rcsid[] =
 #include <stdlib.h>
 #include <string.h>
 #include <stdio.h>
+#include <errno.h>
 #include "ios_error.h"
 
 #ifndef __APPLE__
@@ -90,7 +91,7 @@ makevfslist(fslist)
 		if (*cnextcp == ',')
 			i++;
 	if ((av = malloc((size_t)(i + 2) * sizeof(char *))) == NULL) {
-        fprintf(stderr, "df: malloc failed\n");
+        fprintf(stderr, "df: malloc failed: %s\n", strerror(errno));
         // warnx("malloc failed");
 		return (NULL);
 	}

--- a/Dependencies/ios_system/file_cmds/du/du.c
+++ b/Dependencies/ios_system/file_cmds/du/du.c
@@ -262,7 +262,7 @@ du_main(int argc, char *argv[])
 
     if ((fts = fts_open(argv, ftsoptions, NULL)) == NULL) {
 		// err(1, "fts_open");
-        fprintf(stderr, "du: fts_open\n");
+        fprintf(stderr, "du: fts_open: %s\n", strerror(errno));
         pthread_exit(NULL);
     }
 
@@ -361,7 +361,7 @@ du_main(int argc, char *argv[])
 
     if (errno) {
 		// err(1, "fts_read");
-        fprintf(stderr, "du: fts_read\n");
+        fprintf(stderr, "du: fts_read: %s\n", strerror(errno));
         pthread_exit(NULL);
     }
 

--- a/Dependencies/ios_system/file_cmds/gzip/gzip.c
+++ b/Dependencies/ios_system/file_cmds/gzip/gzip.c
@@ -2011,7 +2011,7 @@ handle_dir(char *dir)
 	fts = fts_open(path_argv, FTS_PHYSICAL | FTS_NOCHDIR, NULL);
 	if (fts == NULL) {
 		// warn("couldn't fts_open %s", dir);
-        fprintf(stderr, "gzip: couldn't fts_open %s\n", dir);
+        fprintf(stderr, "gzip: couldn't fts_open %s: %s\n", dir, strerror(errno));
 		return;
 	}
 

--- a/Dependencies/ios_system/file_cmds/ln/ln.c
+++ b/Dependencies/ios_system/file_cmds/ln/ln.c
@@ -159,12 +159,12 @@ ln_main(int argc, char *argv[])
 		 */
 		errno = ENOTDIR;
 		// err(1, "%s", sourcedir);
-        fprintf(stderr, "ln: %s\n", sourcedir);
+        fprintf(stderr, "ln: %s: %s\n", sourcedir, strerror(errno));
         pthread_exit(NULL);
 	}
     if (stat(sourcedir, &sb)) {
 		// err(1, "%s", sourcedir);
-        fprintf(stderr, "ln: %s\n", sourcedir);
+        fprintf(stderr, "ln: %s: %s\n", sourcedir, strerror(errno));
         pthread_exit(NULL);
     }
 	if (!S_ISDIR(sb.st_mode))
@@ -186,14 +186,14 @@ linkit(const char *target, const char *source, int isdir)
 	if (!sflag) {
 		/* If target doesn't exist, quit now. */
 		if (stat(target, &sb)) {
-            fprintf(stderr, "ln: %s\n", target);
+            fprintf(stderr, "ln: %s: %s\n", target, strerror(errno));
             // warn("%s", target);
 			return (1);
 		}
 		/* Only symbolic links to directories. */
 		if (S_ISDIR(sb.st_mode)) {
 			errno = EISDIR;
-            fprintf(stderr, "ln: %s\n", target);
+            fprintf(stderr, "ln: %s: %s\n", target, strerror(errno));
 			// warn("%s", target);
 			return (1);
 		}
@@ -211,7 +211,7 @@ linkit(const char *target, const char *source, int isdir)
 		    snprintf(path, sizeof(path), "%s/%s", source, p) >=
 		    (ssize_t)sizeof(path)) {
 			errno = ENAMETOOLONG;
-            fprintf(stderr, "ln: %s\n", target);
+            fprintf(stderr, "ln: %s: %s\n", target, strerror(errno));
 			// warn("%s", target);
 			return (1);
 		}
@@ -226,12 +226,12 @@ linkit(const char *target, const char *source, int isdir)
 	if (fflag && exists) {
 		if (Fflag && S_ISDIR(sb.st_mode)) {
 			if (rmdir(source)) {
-                fprintf(stderr, "ln: %s\n", source);
+                fprintf(stderr, "ln: %s: %s\n", source, strerror(errno));
 				// warn("%s", source);
 				return (1);
 			}
 		} else if (unlink(source)) {
-            fprintf(stderr, "ln: %s\n", source);
+            fprintf(stderr, "ln: %s: %s\n", source, strerror(errno));
 			// warn("%s", source);
 			return (1);
 		}
@@ -249,12 +249,12 @@ linkit(const char *target, const char *source, int isdir)
 
 		if (Fflag && S_ISDIR(sb.st_mode)) {
 			if (rmdir(source)) {
-                fprintf(stderr, "ln: %s\n", source);
+                fprintf(stderr, "ln: %s: %s\n", source, strerror(errno));
 				// warn("%s", source);
 				return (1);
 			}
 		} else if (unlink(source)) {
-            fprintf(stderr, "ln: %s\n", source);
+            fprintf(stderr, "ln: %s: %s\n", source, strerror(errno));
 			// warn("%s", source);
 			return (1);
 		}
@@ -262,7 +262,7 @@ linkit(const char *target, const char *source, int isdir)
 
 	/* Attempt the link. */
 	if ((*linkf)(target, source)) {
-        fprintf(stderr, "ln: %s\n", source);
+        fprintf(stderr, "ln: %s: %s\n", source, strerror(errno));
 		// warn("%s", source);
 		return (1);
 	}

--- a/Dependencies/ios_system/file_cmds/ls/ls.c
+++ b/Dependencies/ios_system/file_cmds/ls/ls.c
@@ -559,7 +559,7 @@ traverse(int argc, char *argv[], int options)
 	if ((ftsp =
          fts_open(argv, options, f_nosort ? NULL : mastercmp)) == NULL) {
 		// err(1, "fts_open");
-        fprintf(stderr, "ls: fts_open\n");
+        fprintf(stderr, "ls: fts_open: %s\n", strerror(errno));
         pthread_exit(NULL);
     }
 
@@ -638,7 +638,7 @@ traverse(int argc, char *argv[], int options)
 	errno = error;
 
     if (errno) {
-        fprintf(stderr, "ls: fts_read\n");
+        fprintf(stderr, "ls: fts_read: %s\n", strerror(errno));
         pthread_exit(NULL);
 		// err(1, "fts_read");
     }
@@ -700,7 +700,7 @@ display(FTSENT *p, FTSENT *list)
 		/* Fill-in "::" as "0:0:0" for the sake of scanf. */
 		jinitmax = initmax2 = malloc(strlen(initmax) * 2 + 2);
         if (jinitmax == NULL) {
-			fprintf(stderr, "ls: malloc\n");
+            fprintf(stderr, "ls: malloc: %s\n", strerror((errno)));
             pthread_exit(NULL);
             // err(1, "malloc");
         }
@@ -841,7 +841,7 @@ display(FTSENT *p, FTSENT *list)
 						flags = strdup("-");
 					}
                     if (flags == NULL) {
-						fprintf(stderr, "ls: fflagstostr\n");
+                        fprintf(stderr, "ls: fflagstostr: %s\n", strerror(errno));
                         pthread_exit(NULL);
                         // err(1, "fflagstostr");
                     }
@@ -856,7 +856,7 @@ display(FTSENT *p, FTSENT *list)
 				if ((np = calloc(1, sizeof(NAMES) + lattrlen +
 				    ulen + glen + flen + 4)) == NULL)
                 {
-                    fprintf(stderr, "ls: malloc\n");
+                    fprintf(stderr, "ls: malloc: %s\n", strerror(errno));
                     // err(1, "malloc");
                     pthread_exit(NULL);
                 }

--- a/Dependencies/ios_system/file_cmds/ls/print.c
+++ b/Dependencies/ios_system/file_cmds/ls/print.c
@@ -211,7 +211,7 @@ uuid_to_name(uuid_t *uu)
 	name = (char *) malloc(MAXNAMETAG);
 	
 	if (NULL == name) {
-        fprintf(stderr, "ls: malloc\n");
+        fprintf(stderr, "ls: malloc: %s\n", strerror(errno));
         pthread_exit(NULL);
         // err(1, "malloc");
 	}
@@ -490,7 +490,7 @@ printcol(DISPLAY *dp)
 		lastentries = dp->entries;
 		if ((array = realloc(array, dp->entries * sizeof(FTSENT *))) == NULL) {
 			// warn(NULL);
-            fprintf(stderr, "\n");
+            fprintf(stderr, "%s\n", strerror(errno));
 			printscol(dp);
 			return;
 		}

--- a/Dependencies/ios_system/file_cmds/mkdir/mkdir.c
+++ b/Dependencies/ios_system/file_cmds/mkdir/mkdir.c
@@ -113,16 +113,16 @@ mkdir_main(int argc, char *argv[])
 		if (pflag) {
 			int status = mkpath_np(*argv, omode);
 			if (status && status != EEXIST) {
-                fprintf(stderr, "mkdir: %s\n", *argv);
+                fprintf(stderr, "mkdir: %s: %s\n", *argv, strerror(errno));
                 // warnc(status, "%s", *argv);
 				success = 0;
 			}
 		} else if (mkdir(*argv, omode) < 0) {
 			if (errno == ENOTDIR || errno == ENOENT)
-                fprintf(stderr, "mkdir: %s\n", dirname(*argv));
+                fprintf(stderr, "mkdir: %s: %s\n", dirname(*argv), strerror(errno));
 				// warn("%s", dirname(*argv));
 			else
-                fprintf(stderr, "mkdir: %s\n", *argv);
+                fprintf(stderr, "mkdir: %s: %s\n", *argv, strerror(errno));
 				// warn("%s", *argv);
 			success = 0;
 		} else if (vflag)
@@ -138,7 +138,7 @@ mkdir_main(int argc, char *argv[])
 		 * as chmod will (obviously) ignore the umask.
 		 */
 		if (success && mode != NULL && chmod(*argv, omode) == -1) {
-            fprintf(stderr, "mkdir: %s\n", *argv);
+            fprintf(stderr, "mkdir: %s: %s\n", *argv, strerror(errno));
 			// warn("%s", *argv);
 			exitval = 1;
 		}

--- a/Dependencies/ios_system/file_cmds/rm/rm.c
+++ b/Dependencies/ios_system/file_cmds/rm/rm.c
@@ -206,6 +206,7 @@ rm_tree(argv)
 	if (!(fts = fts_open(argv, flags, NULL))) {
 		if (fflag && errno == ENOENT)
 			return;
+        fprintf(stderr, "rm: %s\n", strerror(errno));
         pthread_exit(NULL);
 		// err(1, NULL);
 	}
@@ -330,14 +331,14 @@ rm_tree(argv)
 			}
 		}
 err:
-        fprintf(stderr, "rm: %s\n", p->fts_path);
+        fprintf(stderr, "rm: %s: %s\n", p->fts_path, strerror(errno));
         // warn("%s", p->fts_path);
 		eval = 1;
 	}
     fts_close(fts);
     if (errno) {
 		// err(1, "fts_read");
-        fprintf(stderr, "rm: fts_read\n");
+        fprintf(stderr, "rm: fts_read: %s\n", strerror(errno));
         pthread_exit(NULL);
     }
 }
@@ -361,7 +362,7 @@ rm_file(argv)
 				sb.st_mode = S_IFWHT|S_IWUSR|S_IRUSR;
 			} else {
 				if (!fflag || errno != ENOENT) {
-                    fprintf(stderr, "rm: %s\n", f);
+                    fprintf(stderr, "rm: %s: %s\n", f, strerror(errno));
                     // warn("%s", f);
 					eval = 1;
 				}
@@ -407,7 +408,7 @@ rm_file(argv)
 			}
 		}
 		if (rval && (!fflag || errno != ENOENT)) {
-            fprintf(stderr, "rm: %s\n", f);
+            fprintf(stderr, "rm: %s: %s\n", f, strerror(errno));
             // warn("%s", f);
 			eval = 1;
 		}
@@ -452,7 +453,7 @@ rm_overwrite(file, sbp)
 	bsize = MAX(fsb.f_iosize, 1024);
     if ((buf = malloc(bsize)) == NULL) {
 		// err(1, "malloc");
-        fprintf(stderr, "rm: malloc\n");
+        fprintf(stderr, "rm: malloc: %s\n", strerror(errno));
         pthread_exit(NULL);
     }
 
@@ -479,7 +480,7 @@ rm_overwrite(file, sbp)
 err:	eval = 1;
 	if (buf)
 		free(buf);
-        fprintf(stderr, "rm: %s\n", file);
+        fprintf(stderr, "rm: %s: %s\n", file, strerror(errno));
     // warn("%s", file);
 }
 
@@ -528,9 +529,11 @@ check(path, name, sp)
 		    (!(sp->st_flags & (UF_APPEND|UF_IMMUTABLE)) || !uid)))
 			return (1);
 		strmode(sp->st_mode, modep);
-        if ((flagsp = fflagstostr(sp->st_flags)) == NULL)
+        if ((flagsp = fflagstostr(sp->st_flags)) == NULL) {
+            fprintf(stderr, "rm: %s\n", strerror(errno));
             pthread_exit(NULL);
 			// err(1, NULL);
+        }
 		(void)fprintf(stderr, "override %s%s%s/%s %s%sfor %s? ",
 		    modep + 1, modep[9] == ' ' ? "" : " ",
 		    user_from_uid(sp->st_uid, 0),

--- a/Dependencies/ios_system/file_cmds/rmdir/rmdir.c
+++ b/Dependencies/ios_system/file_cmds/rmdir/rmdir.c
@@ -83,7 +83,7 @@ rmdir_main(int argc, char *argv[])
 
 	for (errors = 0; *argv; argv++) {
 		if (rmdir(*argv) < 0) {
-            fprintf(stderr, "rmdir: %s\n", *argv);
+            fprintf(stderr, "rmdir: %s: %s\n", *argv, strerror(errno));
             // warn("%s", *argv);
 			errors = 1;
 		} else if (pflag)
@@ -109,7 +109,7 @@ rm_path(char *path)
 		*++p = '\0';
 
 		if (rmdir(path) < 0) {
-            fprintf(stderr, "rmdir: %s\n", path);
+            fprintf(stderr, "rmdir: %s: %s\n", path, strerror(errno));
             // warn("%s", path);
 			return (1);
 		}

--- a/Dependencies/ios_system/file_cmds/stat/stat.c
+++ b/Dependencies/ios_system/file_cmds/stat/stat.c
@@ -67,6 +67,7 @@ __FBSDID("$FreeBSD: src/usr.bin/stat/stat.c,v 1.6 2003/10/06 01:55:17 dougb Exp 
 #include <string.h>
 #include <time.h>
 #include <unistd.h>
+#include <errno.h>
 #include "ios_error.h"
 
 #if HAVE_STRUCT_STAT_ST_FLAGS
@@ -330,8 +331,8 @@ stat_main(int argc, char *argv[])
 			linkfail = 1;
 			if (!quiet)
 				// warn("%s: stat",
-                fprintf(stderr, "star: %s: stat\n",
-				    argc == 0 ? "(stdin)" : argv[0]);
+                fprintf(stderr, "stat: %s: stat: %s\n",
+				    argc == 0 ? "(stdin)" : argv[0], strerror(errno));
 		}
 		else
 			output(&st, argv[0], statfmt, fn, nonl, quiet);

--- a/Dependencies/ios_system/file_cmds/touch/touch.c
+++ b/Dependencies/ios_system/file_cmds/touch/touch.c
@@ -85,7 +85,7 @@ touch_main(int argc, char *argv[])
 	utimes_f = utimes;
     if (gettimeofday(&tv[0], NULL)) {
 		// err(1, "gettimeofday");
-        fprintf(stderr, "touch: gettimeofday\n");
+        fprintf(stderr, "touch: gettimeofday: %s\n", strerror(errno));
         pthread_exit(NULL);
     }
 
@@ -171,7 +171,7 @@ touch_main(int argc, char *argv[])
 		if (stat_f(*argv, &sb) != 0) {
 			if (errno != ENOENT) {
 				rval = 1;
-                fprintf(stderr, "touch: %s\n", *argv);
+                fprintf(stderr, "touch: %s: %s\n", *argv, strerror(errno));
                 // warn("%s", *argv);
 				continue;
 			}
@@ -181,7 +181,7 @@ touch_main(int argc, char *argv[])
 				    O_WRONLY | O_CREAT, DEFFILEMODE);
 				if (fd == -1 || fstat(fd, &sb) || close(fd)) {
 					rval = 1;
-					fprintf(stderr, "touch: %s\n", *argv);
+                    fprintf(stderr, "touch: %s: %s\n", *argv, strerror(errno));
                     // warn("%s", *argv);
 					continue;
 				}
@@ -220,7 +220,7 @@ touch_main(int argc, char *argv[])
 		/* If the user specified a time, nothing else we can do. */
 		if (timeset || Aflag) {
 			rval = 1;
-            fprintf(stderr, "touch: %s\n", *argv);
+            fprintf(stderr, "touch: %s: %s\n", *argv, strerror(errno));
             // warn("%s", *argv);
 			continue;
 		}
@@ -240,7 +240,7 @@ touch_main(int argc, char *argv[])
 				rval = 1;
 		} else {
 			rval = 1;
-            fprintf(stderr, "touch: %s\n", *argv);
+            fprintf(stderr, "touch: %s: %s\n", *argv, strerror(errno));
             // warn("%s", *argv);
 		}
 	}
@@ -260,7 +260,7 @@ stime_arg1(char *arg, struct timeval *tvp)
 	now = tvp[0].tv_sec;
     if ((t = localtime(&now)) == NULL) {
 		// err(1, "localtime");
-        fprintf(stderr, "touch: localtime\n");
+        fprintf(stderr, "touch: localtime: %s\n", strerror(errno));
         pthread_exit(NULL);
     }
 					/* [[CC]YY]MMDDhhmm[.SS] */
@@ -324,7 +324,7 @@ stime_arg2(char *arg, int year, struct timeval *tvp)
 	now = tvp[0].tv_sec;
     if ((t = localtime(&now)) == NULL) {
 		// err(1, "localtime");
-        fprintf(stderr, "touch: localtime\n");
+        fprintf(stderr, "touch: localtime: %s\n", strerror(errno));
         pthread_exit(NULL);
     }
 
@@ -390,7 +390,7 @@ stime_file(char *fname, struct timeval *tvp)
 
     if (stat(fname, &sb)) {
 		// err(1, "%s", fname);
-        fprintf(stderr, "touch: %s\n", fname);
+        fprintf(stderr, "touch: %s: %s\n", fname, strerror(errno));
         pthread_exit(NULL);
     }
 	TIMESPEC_TO_TIMEVAL(tvp, &sb.st_atimespec);
@@ -429,11 +429,11 @@ rw(char *fname, struct stat *sbp, int force)
 	} else {
 		if (write(fd, &byte, sizeof(byte)) != sizeof(byte)) {
 err:			rval = 1;
-            fprintf(stderr, "touch: %s\n", fname);
+            fprintf(stderr, "touch: %s: %s\n", fname, strerror(errno));
             // warn("%s", fname);
 		} else if (ftruncate(fd, (off_t)0)) {
 			rval = 1;
-			fprintf(stderr, "touch: %s: file modified\n", fname);
+            fprintf(stderr, "touch: %s: file modified: %s\n", fname, strerror(errno));
             // warn("%s: file modified", fname);
 		}
 	}
@@ -445,7 +445,7 @@ err:			rval = 1;
 	}
 	if (needed_chmod && chmod(fname, sbp->st_mode) && rval != 1) {
 		rval = 1;
-		fprintf(stderr, "touch: %s: permissions modified\n", fname);
+        fprintf(stderr, "touch: %s: permissions modified: %s\n", fname, strerror(errno));
         // warn("%s: permissions modified", fname);
 	}
 	return (rval);

--- a/Dependencies/ios_system/ios_system.m
+++ b/Dependencies/ios_system/ios_system.m
@@ -19,6 +19,10 @@
 #include <pthread.h>
 #include <sys/stat.h>
 
+// Note: we could use dlsym() to make this code simpler, but it would also make it harder
+// to be accepted in the AppleStore. Dynamic libraries are already loaded, so it would be:
+// function = dlsym(argv[0] + "_main", RTLD_DEFAULT);
+
 #define FILE_UTILITIES   // file_cmds_ios
 #define ARCHIVE_UTILITIES // libarchive_ios
 #define SHELL_UTILITIES  // shell_cmds_ios
@@ -28,14 +32,9 @@
 #define CURL_COMMANDS
 // to activate TEX_COMMANDS, you need the lib-tex libraries:
 // See: https://github.com/holzschu/lib-tex
-// #define TEX_COMMANDS    // pdftex, luatex, bibtex and the like
-// to activate Python, you need python-ios: https://github.com/holzschu/python_ios
-// #define FEAT_PYTHON
-// to activate Lua, you need lua-ios: https://github.com/holzschu/lua_ios
-// #define FEAT_LUA
-
-//#define NETWORK_UTILITIES
-
+#define TEX_COMMANDS    // pdftex, luatex, bibtex and the like
+#define FEAT_PYTHON // if you don't need Python, you can remove Python_grp
+#define FEAT_LUA // if you don't need Lua, you can remove lua_grp
 
 #ifdef FILE_UTILITIES
 // Most useful file utilities (file_cmds_ios)
@@ -103,13 +102,24 @@ typedef struct _functionParameters {
 } functionParameters;
 
 static void* run_function(void* parameters) {
+    static bool isMainThread = true;
     // re-initialize for getopt:
     optind = 1;
     opterr = 1;
     optreset = 1;
     __db_getopt_reset = 1;
     functionParameters *p = (functionParameters *) parameters;
-    p->function(p->argc, p->argv);
+    // Send a signal to the system that we're going to change the current directory:
+    if (isMainThread) {
+        NSString* currentPath = [[NSFileManager defaultManager] currentDirectoryPath];
+        NSURL* currentURL = [NSURL fileURLWithPath:currentPath];
+        NSFileCoordinator *fileCoordinator =  [[NSFileCoordinator alloc] initWithFilePresenter:nil];
+        [fileCoordinator coordinateWritingItemAtURL:currentURL options:0 error:NULL byAccessor:^(NSURL *currentURL) {
+            isMainThread = false;
+            p->function(p->argc, p->argv);
+            isMainThread = true;
+        }];
+    } else p->function(p->argc, p->argv); // but don't do it if a command starts another command (would be overkill)
     return NULL;
 }
 
@@ -117,6 +127,7 @@ static NSDictionary *commandList = nil;
 // do recompute directoriesInPath only if $PATH has changed
 static NSString* fullCommandPath = @"";
 static NSArray *directoriesInPath;
+
 
 
 static void initializeCommandList()
@@ -133,12 +144,12 @@ static void initializeCommandList()
                     @"mv" : [NSValue valueWithPointer: mv_main],
                     @"mkdir" : [NSValue valueWithPointer: mkdir_main],
                     @"rmdir" : [NSValue valueWithPointer: rmdir_main],
-//                    @"chown" : [NSValue valueWithPointer: chown_main],
-//                    @"chgrp" : [NSValue valueWithPointer: chown_main],
+                    @"chown" : [NSValue valueWithPointer: chown_main],
+                    @"chgrp" : [NSValue valueWithPointer: chown_main],
                     @"chflags": [NSValue valueWithPointer: chflags_main],
-//                    @"chmod": [NSValue valueWithPointer: chmod_main],
+                    @"chmod": [NSValue valueWithPointer: chmod_main],
                     @"du"   : [NSValue valueWithPointer: du_main],
-//                    @"df"   : [NSValue valueWithPointer: df_main],
+                    @"df"   : [NSValue valueWithPointer: df_main],
                     @"chksum" : [NSValue valueWithPointer: chksum_main],
                     @"sum"    : [NSValue valueWithPointer: chksum_main],
                     @"stat"   : [NSValue valueWithPointer: stat_main],
@@ -155,15 +166,15 @@ static void initializeCommandList()
 #ifdef SHELL_UTILITIES
                     // Commands from Apple shell_cmds:
                     @"printenv": [NSValue valueWithPointer: printenv_main],
-//                    @"pwd"    : [NSValue valueWithPointer: pwd_main],
+                    @"pwd"    : [NSValue valueWithPointer: pwd_main],
                     @"uname"  : [NSValue valueWithPointer: uname_main],
                     @"date"   : [NSValue valueWithPointer: date_main],
-//                    @"env"    : [NSValue valueWithPointer: env_main],
-//                    @"id"     : [NSValue valueWithPointer: id_main],
-//                    @"groups" : [NSValue valueWithPointer: id_main],
+                    @"env"    : [NSValue valueWithPointer: env_main],
+                    @"id"     : [NSValue valueWithPointer: id_main],
+                    @"groups" : [NSValue valueWithPointer: id_main],
                     @"whoami" : [NSValue valueWithPointer: id_main],
                     @"uptime" : [NSValue valueWithPointer: w_main],
-//                    @"w"      : [NSValue valueWithPointer: w_main],
+                    @"w"      : [NSValue valueWithPointer: w_main],
 #endif
 #ifdef TEXT_UTILITIES
                     // Commands from Apple text_cmds:
@@ -279,9 +290,13 @@ int ios_system(char* inputCmd) {
     // fprintf(stderr, "Command sent: %s \n", cmd); fflush(stderr);
     if (cmd[0] == '"') {
         // Command was enclosed in quotes (almost always with Vim)
-        cmd = cmd + 1; // remove starting quote
-        cmd[strlen(cmd) - 1] = 0x00; // remove ending quote
-        assert(cmd + strlen(cmd) < maxPointer);
+        char* endCmd = strstr(cmd + 1, "\""); // find closing quote
+        if (endCmd) {
+            cmd = cmd + 1; // remove starting quote
+            endCmd[0] = 0x0;
+            assert(endCmd < maxPointer);
+        }
+        // assert(cmd + strlen(cmd) < maxPointer);
     }
     if (cmd[0] == '(') {
         // Standard vim encoding: command between parentheses
@@ -373,6 +388,10 @@ int ios_system(char* inputCmd) {
     if (errorFileMarker) errorFileMarker[0] = 0x0;
     // Store previous values of stdin, stdout, stderr:
     // fprintf(stdout, "before, stderr = %x\n", (void*)stderr);
+    // strip filenames of quotes, if any:
+    if (outputFileName && (outputFileName[0] == '\'')) { outputFileName = outputFileName + 1; outputFileName[strlen(outputFileName) - 1] = 0x0; }
+    if (inputFileName && (inputFileName[0] == '\'')) { inputFileName = inputFileName + 1; inputFileName[strlen(inputFileName) - 1] = 0x0; }
+    if (errorFileName && (errorFileName[0] == '\'')) { errorFileName = errorFileName + 1; errorFileName[strlen(errorFileName) - 1] = 0x0; }
     FILE* push_stdin = stdin;
     FILE* push_stdout = stdout;
     FILE* push_stderr = stderr;
@@ -517,6 +536,7 @@ int ios_system(char* inputCmd) {
         int (*function)(int ac, char** av) = NULL;
         if (commandList == nil) initializeCommandList();
         NSString* commandName = [NSString stringWithCString:argv[0] encoding:NSASCIIStringEncoding];
+        // Insert code here. With #ifdef ???
         function = [[commandList objectForKey: commandName] pointerValue];
         if (function) {
             // We run the function in a thread because there are several
@@ -532,6 +552,7 @@ int ios_system(char* inputCmd) {
             pthread_join(_tid, NULL);
             // free(params);
         } else {
+            // TODO: this should also raise an exception, for python scripts
             fprintf(stderr, "%s: command not found\n", argv[0]);
         }
     }

--- a/Dependencies/ios_system/ios_system.m
+++ b/Dependencies/ios_system/ios_system.m
@@ -528,7 +528,7 @@ int ios_system(char* inputCmd) {
                 if (cmdIsAFile) break; // else keep going through the path elements.
             }
         }
-        fprintf(stderr, "Command after parsing: ");
+        // fprintf(stderr, "Command after parsing: ");
         // for (int i = 0; i < argc; i++)
         //    fprintf(stderr, "[%s] ", argv[i]);
         // We've reached this point: either the command is a file, from a script we support,

--- a/Dependencies/ios_system/ios_system.m
+++ b/Dependencies/ios_system/ios_system.m
@@ -85,6 +85,9 @@ extern int w_main(int argc, char *argv[]); // also uptime
 extern int cat_main(int argc, char *argv[]);
 extern int grep_main(int argc, char *argv[]);
 extern int wc_main(int argc, char *argv[]);
+extern int ed_main(int argc, char *argv[]);
+extern int sed_main(int argc, char *argv[]);
+extern int awk_main(int argc, char *argv[]);
 #endif
 #ifdef FEAT_LUA
 extern int lua_main(int argc, char *argv[]);
@@ -181,12 +184,13 @@ void initializeEnvironment() {
 #endif
 }
 
-static char* parseArgument(char* argument) {
+static char* parseArgument(char* argument, char* command) {
     // expand all environment variables, convert "~" to $HOME (only if localFile)
+    // we also pass the shell command for some specific behaviour (don't do this for that command)
     NSString* argumentString = [NSString stringWithCString:argument encoding:NSASCIIStringEncoding];
     // 1) expand environment variables, + "~" (not wildcards ? and *)
     bool cannotExpand = false;
-    while ([argumentString containsString:@"$"]) {
+    while ([argumentString containsString:@"$"] && !cannotExpand) {
         // It has environment variables inside. Work on them one by one.
         // position of first "$" sign:
         NSRange r1 = [argumentString rangeOfString:@"$"];
@@ -220,23 +224,26 @@ static char* parseArgument(char* argument) {
     }
     // Also convert ":~something" in PATH style variables
     // We don't use these yet, but we could.
-    // This is something we need to avoid if the command is "scp" or "sftp"
-    if ([argumentString containsString:@":~"]) {
-        // Only 1 possibility: ":~" (same as $HOME)
-        if (getenv("HOME")) {
-            if ([argumentString containsString:@":~/"]) {
-                NSString* test_string = @":~/";
-                NSString* replacement_string = [[NSString stringWithCString:":" encoding:NSASCIIStringEncoding] stringByAppendingString:[NSString stringWithCString:(getenv("HOME")) encoding:NSASCIIStringEncoding]];
-                replacement_string = [replacement_string stringByAppendingString:[NSString stringWithCString:"/" encoding:NSASCIIStringEncoding]];
-                argumentString = [argumentString stringByReplacingOccurrencesOfString:test_string withString:replacement_string];
-            } else if ([argumentString hasSuffix:@":~"]) {
-                NSString* test_string = @":~";
-                NSString* replacement_string = [[NSString stringWithCString:":" encoding:NSASCIIStringEncoding] stringByAppendingString:[NSString stringWithCString:(getenv("HOME")) encoding:NSASCIIStringEncoding]];
-                argumentString = [argumentString stringByReplacingOccurrencesOfString:test_string withString:replacement_string options:NULL range:NSMakeRange([argumentString length] - 2, 2)];
-            } else if ([argumentString hasSuffix:@":"]) {
-                NSString* test_string = @":";
-                NSString* replacement_string = [[NSString stringWithCString:":" encoding:NSASCIIStringEncoding] stringByAppendingString:[NSString stringWithCString:(getenv("HOME")) encoding:NSASCIIStringEncoding]];
-                argumentString = [argumentString stringByReplacingOccurrencesOfString:test_string withString:replacement_string options:NULL range:NSMakeRange([argumentString length] - 2, 2)];
+    // We do this expansion only for setenv
+    if (strcmp(command, "setenv") == 0) {
+        // This is something we need to avoid if the command is "scp" or "sftp"
+        if ([argumentString containsString:@":~"]) {
+            // Only 1 possibility: ":~" (same as $HOME)
+            if (getenv("HOME")) {
+                if ([argumentString containsString:@":~/"]) {
+                    NSString* test_string = @":~/";
+                    NSString* replacement_string = [[NSString stringWithCString:":" encoding:NSASCIIStringEncoding] stringByAppendingString:[NSString stringWithCString:(getenv("HOME")) encoding:NSASCIIStringEncoding]];
+                    replacement_string = [replacement_string stringByAppendingString:[NSString stringWithCString:"/" encoding:NSASCIIStringEncoding]];
+                    argumentString = [argumentString stringByReplacingOccurrencesOfString:test_string withString:replacement_string];
+                } else if ([argumentString hasSuffix:@":~"]) {
+                    NSString* test_string = @":~";
+                    NSString* replacement_string = [[NSString stringWithCString:":" encoding:NSASCIIStringEncoding] stringByAppendingString:[NSString stringWithCString:(getenv("HOME")) encoding:NSASCIIStringEncoding]];
+                    argumentString = [argumentString stringByReplacingOccurrencesOfString:test_string withString:replacement_string options:NULL range:NSMakeRange([argumentString length] - 2, 2)];
+                } else if ([argumentString hasSuffix:@":"]) {
+                    NSString* test_string = @":";
+                    NSString* replacement_string = [[NSString stringWithCString:":" encoding:NSASCIIStringEncoding] stringByAppendingString:[NSString stringWithCString:(getenv("HOME")) encoding:NSASCIIStringEncoding]];
+                    argumentString = [argumentString stringByReplacingOccurrencesOfString:test_string withString:replacement_string options:NULL range:NSMakeRange([argumentString length] - 2, 2)];
+                }
             }
         }
     }
@@ -284,10 +291,10 @@ static void initializeCommandList()
 #ifdef SHELL_UTILITIES
                     // Commands from Apple shell_cmds:
                     @"printenv": [NSValue valueWithPointer: printenv_main],
-//                    @"pwd"    : [NSValue valueWithPointer: pwd_main],
+                    @"pwd"    : [NSValue valueWithPointer: pwd_main],
                     @"uname"  : [NSValue valueWithPointer: uname_main],
                     @"date"   : [NSValue valueWithPointer: date_main],
-//                    @"env"    : [NSValue valueWithPointer: env_main],
+                    @"env"    : [NSValue valueWithPointer: env_main],
 //                    @"id"     : [NSValue valueWithPointer: id_main],
 //                    @"groups" : [NSValue valueWithPointer: id_main],
                     @"whoami" : [NSValue valueWithPointer: id_main],
@@ -298,6 +305,11 @@ static void initializeCommandList()
                     // Commands from Apple text_cmds:
                     @"cat"    : [NSValue valueWithPointer: cat_main],
                     @"wc"     : [NSValue valueWithPointer: wc_main],
+                    // compiled, but deactivated until we have interactive mode
+//                    @"ed"     : [NSValue valueWithPointer: ed_main],
+//                    @"red"     : [NSValue valueWithPointer: ed_main],
+                    @"sed"     : [NSValue valueWithPointer: sed_main],
+                    @"awk"     : [NSValue valueWithPointer: awk_main],
                     @"grep"   : [NSValue valueWithPointer: grep_main],
                     @"egrep"  : [NSValue valueWithPointer: grep_main],
                     @"fgrep"  : [NSValue valueWithPointer: grep_main],
@@ -313,8 +325,8 @@ static void initializeCommandList()
                     // http, https, ftp... should be OK.
                     @"curl"   : [NSValue valueWithPointer: curl_main],
                     // scp / sftp require conversion to curl, rewriting arguments
-                    // @"scp"    : [NSValue valueWithPointer: curl_main],
-                    // @"sftp"   : [NSValue valueWithPointer: curl_main],
+                    @"scp"    : [NSValue valueWithPointer: curl_main],
+                    @"sftp"   : [NSValue valueWithPointer: curl_main],
 #endif
 #ifdef FEAT_PYTHON
                     // from python:
@@ -580,10 +592,12 @@ int ios_system(char* inputCmd) {
     char* str = command;
     while(*str) if (*str++ == ' ') ++numSpaces;
     char** argv = (char **)malloc(sizeof(char*) * (numSpaces + 2));
+    bool* dontExpand = malloc(sizeof(bool) * (numSpaces + 2));
     // n spaces = n+1 arguments, plus null at the end
     str = command;
     while (*str) {
         argv[argc] = str;
+        dontExpand[argc] = false;
         argc += 1;
         if (str[0] == '\'') { // argument begins with a quote.
             // everything until next quote is part of the argument
@@ -599,6 +613,7 @@ int ios_system(char* inputCmd) {
             if (!end) break;
             end[0] = 0x0;
             str = end + 1;
+            dontExpand[argc-1] = true; // don't expand arguments in quotes
         } else {
             // skip to next space:
             char* end = strstr(str, " ");
@@ -610,18 +625,21 @@ int ios_system(char* inputCmd) {
         while (str && (str[0] == ' ')) str++; // skip multiple spaces
     }
     argv[argc] = NULL;
-    // So far, all arguments are pointers into originalCommand.
-    // We need to change them (environment variables expansion, ~ expansion, etc)
-    // Duplicate everything so we can realloc:
-    char** argv_copy = (char **)malloc(sizeof(char*) * (argc + 1));
-    for (int i = 0; i < argc; i++) argv_copy[i] = strdup(argv[i]);
-    argv_copy[argc] = NULL;
-    free(argv);
-    argv = argv_copy;
-    // We have the arguments. Parse them for environment variables, ~, etc.
-    for (int i = 1; i < argc; i++) argv[i] = parseArgument(argv[i]);
-    
     if (argc != 0) {
+        // So far, all arguments are pointers into originalCommand.
+        // We need to change them (environment variables expansion, ~ expansion, etc)
+        // Duplicate everything so we can realloc:
+        char** argv_copy = (char **)malloc(sizeof(char*) * (argc + 1));
+        for (int i = 0; i < argc; i++) argv_copy[i] = strdup(argv[i]);
+        argv_copy[argc] = NULL;
+        free(argv);
+        argv = argv_copy;
+        // We have the arguments. Parse them for environment variables, ~, etc.
+        for (int i = 1; i < argc; i++) if (!dontExpand[i]) argv[i] = parseArgument(argv[i], argv[0]);
+        free(dontExpand); 
+        // Because some commands change argv, keep a local copy for release.
+        char** argv_ref = (char **)malloc(sizeof(char*) * (argc + 1));
+        for (int i = 0; i < argc; i++) argv_ref[i] = argv[i];
         // Now call the actual command:
         // - is argv[0] a command that refers to a file? (either absolute path, or in $PATH)
         //   if so, does it exist, does it have +x bit set, does it have #! python or #! lua on the first line?
@@ -738,9 +756,10 @@ int ios_system(char* inputCmd) {
         } else {
             // TODO: this should also raise an exception, for python scripts
             fprintf(stderr, "%s: command not found\n", argv[0]);
-        }
-    }
-    for (int i = 0; i < argc; i++) free(argv[i]);
+        } // if (function)
+        for (int i = 0; i < argc; i++) free(argv_ref[i]);
+        free(argv_ref);
+    } // argc != 0
     free(argv);
     free(originalCommand); // releases cmd
     // Did we write anything?

--- a/Dependencies/ios_system/ios_system.m
+++ b/Dependencies/ios_system/ios_system.m
@@ -32,9 +32,14 @@
 #define CURL_COMMANDS
 // to activate TEX_COMMANDS, you need the lib-tex libraries:
 // See: https://github.com/holzschu/lib-tex
-#define TEX_COMMANDS    // pdftex, luatex, bibtex and the like
-#define FEAT_PYTHON // if you don't need Python, you can remove Python_grp
-#define FEAT_LUA // if you don't need Lua, you can remove lua_grp
+// #define TEX_COMMANDS    // pdftex, luatex, bibtex and the like
+// to activate Python, you need python-ios: https://github.com/holzschu/python_ios
+// #define FEAT_PYTHON
+// to activate Lua, you need lua-ios: https://github.com/holzschu/lua_ios
+// #define FEAT_LUA
+
+//#define NETWORK_UTILITIES
+
 
 #ifdef FILE_UTILITIES
 // Most useful file utilities (file_cmds_ios)
@@ -129,7 +134,6 @@ static NSString* fullCommandPath = @"";
 static NSArray *directoriesInPath;
 
 
-
 static void initializeCommandList()
 {
     commandList = @{
@@ -144,12 +148,12 @@ static void initializeCommandList()
                     @"mv" : [NSValue valueWithPointer: mv_main],
                     @"mkdir" : [NSValue valueWithPointer: mkdir_main],
                     @"rmdir" : [NSValue valueWithPointer: rmdir_main],
-                    @"chown" : [NSValue valueWithPointer: chown_main],
-                    @"chgrp" : [NSValue valueWithPointer: chown_main],
+//                    @"chown" : [NSValue valueWithPointer: chown_main],
+//                    @"chgrp" : [NSValue valueWithPointer: chown_main],
                     @"chflags": [NSValue valueWithPointer: chflags_main],
-                    @"chmod": [NSValue valueWithPointer: chmod_main],
+//                    @"chmod": [NSValue valueWithPointer: chmod_main],
                     @"du"   : [NSValue valueWithPointer: du_main],
-                    @"df"   : [NSValue valueWithPointer: df_main],
+//                    @"df"   : [NSValue valueWithPointer: df_main],
                     @"chksum" : [NSValue valueWithPointer: chksum_main],
                     @"sum"    : [NSValue valueWithPointer: chksum_main],
                     @"stat"   : [NSValue valueWithPointer: stat_main],
@@ -166,15 +170,15 @@ static void initializeCommandList()
 #ifdef SHELL_UTILITIES
                     // Commands from Apple shell_cmds:
                     @"printenv": [NSValue valueWithPointer: printenv_main],
-                    @"pwd"    : [NSValue valueWithPointer: pwd_main],
+//                    @"pwd"    : [NSValue valueWithPointer: pwd_main],
                     @"uname"  : [NSValue valueWithPointer: uname_main],
                     @"date"   : [NSValue valueWithPointer: date_main],
-                    @"env"    : [NSValue valueWithPointer: env_main],
-                    @"id"     : [NSValue valueWithPointer: id_main],
-                    @"groups" : [NSValue valueWithPointer: id_main],
+//                    @"env"    : [NSValue valueWithPointer: env_main],
+//                    @"id"     : [NSValue valueWithPointer: id_main],
+//                    @"groups" : [NSValue valueWithPointer: id_main],
                     @"whoami" : [NSValue valueWithPointer: id_main],
                     @"uptime" : [NSValue valueWithPointer: w_main],
-                    @"w"      : [NSValue valueWithPointer: w_main],
+//                    @"w"      : [NSValue valueWithPointer: w_main],
 #endif
 #ifdef TEXT_UTILITIES
                     // Commands from Apple text_cmds:
@@ -528,7 +532,7 @@ int ios_system(char* inputCmd) {
                 if (cmdIsAFile) break; // else keep going through the path elements.
             }
         }
-        // fprintf(stderr, "Command after parsing: ");
+        fprintf(stderr, "Command after parsing: ");
         // for (int i = 0; i < argc; i++)
         //    fprintf(stderr, "[%s] ", argv[i]);
         // We've reached this point: either the command is a file, from a script we support,

--- a/Dependencies/ios_system/ios_system.xcodeproj/project.pbxproj
+++ b/Dependencies/ios_system/ios_system.xcodeproj/project.pbxproj
@@ -10,6 +10,27 @@
 		22319FA01FDC2332004D875A /* getopt.c in Sources */ = {isa = PBXBuildFile; fileRef = 22319F9E1FDC2332004D875A /* getopt.c */; };
 		223496B01FD5FC71007ED1A9 /* ios_system.h in Headers */ = {isa = PBXBuildFile; fileRef = 223496AE1FD5FC71007ED1A9 /* ios_system.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		223496B71FD5FC89007ED1A9 /* ios_system.m in Sources */ = {isa = PBXBuildFile; fileRef = 223496B61FD5FC89007ED1A9 /* ios_system.m */; };
+		2248DB3920062EB400F2944C /* b.c in Sources */ = {isa = PBXBuildFile; fileRef = 2248DB202004F82700F2944C /* b.c */; };
+		2248DB3A20062EB400F2944C /* lex.c in Sources */ = {isa = PBXBuildFile; fileRef = 2248DB1E2004F82600F2944C /* lex.c */; };
+		2248DB3B20062EB400F2944C /* lib.c in Sources */ = {isa = PBXBuildFile; fileRef = 2248DB1F2004F82600F2944C /* lib.c */; };
+		2248DB3C20062EB400F2944C /* main.c in Sources */ = {isa = PBXBuildFile; fileRef = 2248DB242004F82700F2944C /* main.c */; };
+		2248DB3D20062EB400F2944C /* parse.c in Sources */ = {isa = PBXBuildFile; fileRef = 2248DB1D2004F82600F2944C /* parse.c */; };
+		2248DB3E20062EB400F2944C /* proctab.c in Sources */ = {isa = PBXBuildFile; fileRef = 2248DB232004F82700F2944C /* proctab.c */; };
+		2248DB3F20062EB400F2944C /* run.c in Sources */ = {isa = PBXBuildFile; fileRef = 2248DB1B2004F82600F2944C /* run.c */; };
+		2248DB4020062EB400F2944C /* tran.c in Sources */ = {isa = PBXBuildFile; fileRef = 2248DB212004F82700F2944C /* tran.c */; };
+		2248DB4120062EB400F2944C /* ytab.c in Sources */ = {isa = PBXBuildFile; fileRef = 2248DB1A2004F82600F2944C /* ytab.c */; };
+		2248DB4220062EBB00F2944C /* compile.c in Sources */ = {isa = PBXBuildFile; fileRef = 2248DB142004C5DB00F2944C /* compile.c */; };
+		2248DB4320062EBB00F2944C /* main.c in Sources */ = {isa = PBXBuildFile; fileRef = 2248DB122004C5DB00F2944C /* main.c */; };
+		2248DB4420062EBB00F2944C /* misc.c in Sources */ = {isa = PBXBuildFile; fileRef = 2248DB112004C5DB00F2944C /* misc.c */; };
+		2248DB4520062EBB00F2944C /* process.c in Sources */ = {isa = PBXBuildFile; fileRef = 2248DB132004C5DB00F2944C /* process.c */; };
+		2248DB4620062EC000F2944C /* buf.c in Sources */ = {isa = PBXBuildFile; fileRef = 2248DB062004A5F900F2944C /* buf.c */; settings = {COMPILER_FLAGS = "-x objective-c"; }; };
+		2248DB4720062EC000F2944C /* cbc.c in Sources */ = {isa = PBXBuildFile; fileRef = 2248DB052004A5F900F2944C /* cbc.c */; };
+		2248DB4820062EC000F2944C /* glbl.c in Sources */ = {isa = PBXBuildFile; fileRef = 2248DB012004A5F800F2944C /* glbl.c */; };
+		2248DB4920062EC000F2944C /* io.c in Sources */ = {isa = PBXBuildFile; fileRef = 2248DB022004A5F800F2944C /* io.c */; };
+		2248DB4A20062EC000F2944C /* main.c in Sources */ = {isa = PBXBuildFile; fileRef = 2248DB002004A5F800F2944C /* main.c */; };
+		2248DB4B20062EC000F2944C /* re.c in Sources */ = {isa = PBXBuildFile; fileRef = 2248DB072004A5F900F2944C /* re.c */; };
+		2248DB4C20062EC000F2944C /* sub.c in Sources */ = {isa = PBXBuildFile; fileRef = 2248DB042004A5F900F2944C /* sub.c */; };
+		2248DB4D20062EC000F2944C /* undo.c in Sources */ = {isa = PBXBuildFile; fileRef = 2248DB032004A5F900F2944C /* undo.c */; };
 		22577E481FDB47A90050F312 /* err.c in Sources */ = {isa = PBXBuildFile; fileRef = 22577D451FDB47A90050F312 /* err.c */; settings = {COMPILER_FLAGS = "-DHAVE_CONFIG_H "; }; };
 		22577E491FDB47A90050F312 /* lafe_err.h in Headers */ = {isa = PBXBuildFile; fileRef = 22577D461FDB47A90050F312 /* lafe_err.h */; };
 		22577E4A1FDB47A90050F312 /* lafe_platform.h in Headers */ = {isa = PBXBuildFile; fileRef = 22577D471FDB47A90050F312 /* lafe_platform.h */; };
@@ -521,6 +542,7 @@
 		22CF27C61FDB43080087DDAD /* util.c in Sources */ = {isa = PBXBuildFile; fileRef = 22CF27B71FDB43070087DDAD /* util.c */; settings = {COMPILER_FLAGS = "-DWITHOUT_FASTMATCH"; }; };
 		22CF27C81FDB43080087DDAD /* cat.c in Sources */ = {isa = PBXBuildFile; fileRef = 22CF27BA1FDB43070087DDAD /* cat.c */; };
 		22CF27CC1FDB43080087DDAD /* wc.c in Sources */ = {isa = PBXBuildFile; fileRef = 22CF27C01FDB43080087DDAD /* wc.c */; };
+		22EB965A20065366009E39D0 /* libresolv.9.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 22EB965920065366009E39D0 /* libresolv.9.tbd */; };
 		BE3767C71FEC42D000D5A2D1 /* openssl.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 22257E801FDA7C0C00FBA97D /* openssl.framework */; settings = {ATTRIBUTES = (Required, ); }; };
 		BE3767C91FEC42DD00D5A2D1 /* libssh2.a in Frameworks */ = {isa = PBXBuildFile; fileRef = BE3767C81FEC42DD00D5A2D1 /* libssh2.a */; settings = {ATTRIBUTES = (Required, ); }; };
 		BE3768E01FEC438F00D5A2D1 /* libssl.a in Frameworks */ = {isa = PBXBuildFile; fileRef = BE3768DE1FEC438F00D5A2D1 /* libssl.a */; };
@@ -534,6 +556,27 @@
 		223496AE1FD5FC71007ED1A9 /* ios_system.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ios_system.h; sourceTree = "<group>"; };
 		223496AF1FD5FC71007ED1A9 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		223496B61FD5FC89007ED1A9 /* ios_system.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ios_system.m; sourceTree = "<group>"; };
+		2248DB002004A5F800F2944C /* main.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = main.c; path = text_cmds/ed/main.c; sourceTree = SOURCE_ROOT; };
+		2248DB012004A5F800F2944C /* glbl.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = glbl.c; path = text_cmds/ed/glbl.c; sourceTree = SOURCE_ROOT; };
+		2248DB022004A5F800F2944C /* io.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = io.c; path = text_cmds/ed/io.c; sourceTree = SOURCE_ROOT; };
+		2248DB032004A5F900F2944C /* undo.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = undo.c; path = text_cmds/ed/undo.c; sourceTree = SOURCE_ROOT; };
+		2248DB042004A5F900F2944C /* sub.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = sub.c; path = text_cmds/ed/sub.c; sourceTree = SOURCE_ROOT; };
+		2248DB052004A5F900F2944C /* cbc.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = cbc.c; path = text_cmds/ed/cbc.c; sourceTree = SOURCE_ROOT; };
+		2248DB062004A5F900F2944C /* buf.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = buf.c; path = text_cmds/ed/buf.c; sourceTree = SOURCE_ROOT; };
+		2248DB072004A5F900F2944C /* re.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = re.c; path = text_cmds/ed/re.c; sourceTree = SOURCE_ROOT; };
+		2248DB112004C5DB00F2944C /* misc.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = misc.c; path = text_cmds/sed/misc.c; sourceTree = SOURCE_ROOT; };
+		2248DB122004C5DB00F2944C /* main.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = main.c; path = text_cmds/sed/main.c; sourceTree = SOURCE_ROOT; };
+		2248DB132004C5DB00F2944C /* process.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = process.c; path = text_cmds/sed/process.c; sourceTree = SOURCE_ROOT; };
+		2248DB142004C5DB00F2944C /* compile.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = compile.c; path = text_cmds/sed/compile.c; sourceTree = SOURCE_ROOT; };
+		2248DB1A2004F82600F2944C /* ytab.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = ytab.c; path = "awk-23.30.1/src/ytab.c"; sourceTree = SOURCE_ROOT; };
+		2248DB1B2004F82600F2944C /* run.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = run.c; path = "awk-23.30.1/src/run.c"; sourceTree = SOURCE_ROOT; };
+		2248DB1D2004F82600F2944C /* parse.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = parse.c; path = "awk-23.30.1/src/parse.c"; sourceTree = SOURCE_ROOT; };
+		2248DB1E2004F82600F2944C /* lex.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = lex.c; path = "awk-23.30.1/src/lex.c"; sourceTree = SOURCE_ROOT; };
+		2248DB1F2004F82600F2944C /* lib.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = lib.c; path = "awk-23.30.1/src/lib.c"; sourceTree = SOURCE_ROOT; };
+		2248DB202004F82700F2944C /* b.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = b.c; path = "awk-23.30.1/src/b.c"; sourceTree = SOURCE_ROOT; };
+		2248DB212004F82700F2944C /* tran.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = tran.c; path = "awk-23.30.1/src/tran.c"; sourceTree = SOURCE_ROOT; };
+		2248DB232004F82700F2944C /* proctab.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = proctab.c; path = "awk-23.30.1/src/proctab.c"; sourceTree = SOURCE_ROOT; };
+		2248DB242004F82700F2944C /* main.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = main.c; path = "awk-23.30.1/src/main.c"; sourceTree = SOURCE_ROOT; };
 		22577D451FDB47A90050F312 /* err.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = err.c; sourceTree = "<group>"; };
 		22577D461FDB47A90050F312 /* lafe_err.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = lafe_err.h; sourceTree = "<group>"; };
 		22577D471FDB47A90050F312 /* lafe_platform.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = lafe_platform.h; sourceTree = "<group>"; };
@@ -1045,6 +1088,7 @@
 		22CF27B71FDB43070087DDAD /* util.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = util.c; sourceTree = "<group>"; };
 		22CF27BA1FDB43070087DDAD /* cat.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = cat.c; sourceTree = "<group>"; };
 		22CF27C01FDB43080087DDAD /* wc.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = wc.c; sourceTree = "<group>"; };
+		22EB965920065366009E39D0 /* libresolv.9.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libresolv.9.tbd; path = usr/lib/libresolv.9.tbd; sourceTree = SDKROOT; };
 		BE3767C81FEC42DD00D5A2D1 /* libssh2.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libssh2.a; path = "../libssh2-for-iOS/lib/libssh2.a"; sourceTree = "<group>"; };
 		BE3767CC1FEC430600D5A2D1 /* c_hash */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = c_hash; sourceTree = "<group>"; };
 		BE3767CD1FEC430600D5A2D1 /* CA.sh */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = CA.sh; sourceTree = "<group>"; };
@@ -1318,6 +1362,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				22EB965A20065366009E39D0 /* libresolv.9.tbd in Frameworks */,
 				BE3768E31FEC460100D5A2D1 /* libcrypto.a in Frameworks */,
 				BE3768E01FEC438F00D5A2D1 /* libssl.a in Frameworks */,
 				BE3767C91FEC42DD00D5A2D1 /* libssh2.a in Frameworks */,
@@ -1340,6 +1385,7 @@
 				226378CA1FDB3F2B00AE8827 /* shell_cmds_ios */,
 				22CF27B01FDB42F50087DDAD /* text_cmds_grp */,
 				22577D401FDB478E0050F312 /* libarchive_grp */,
+				2248DB192004F7F100F2944C /* awk */,
 				22577F9D1FDB4D220050F312 /* curl_grp */,
 				223496B61FD5FC89007ED1A9 /* ios_system.m */,
 				223496AD1FD5FC71007ED1A9 /* ios_system */,
@@ -1368,6 +1414,7 @@
 		223497AB1FD6CF7A007ED1A9 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				22EB965920065366009E39D0 /* libresolv.9.tbd */,
 				BE3768DD1FEC438E00D5A2D1 /* libcrypto.a */,
 				BE3768E21FEC460000D5A2D1 /* libcrypto.a */,
 				BE3768DE1FEC438F00D5A2D1 /* libssl.a */,
@@ -1379,6 +1426,49 @@
 				22257E801FDA7C0C00FBA97D /* openssl.framework */,
 			);
 			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		2248DAFF2004A58600F2944C /* ed */ = {
+			isa = PBXGroup;
+			children = (
+				2248DB062004A5F900F2944C /* buf.c */,
+				2248DB052004A5F900F2944C /* cbc.c */,
+				2248DB012004A5F800F2944C /* glbl.c */,
+				2248DB022004A5F800F2944C /* io.c */,
+				2248DB002004A5F800F2944C /* main.c */,
+				2248DB072004A5F900F2944C /* re.c */,
+				2248DB042004A5F900F2944C /* sub.c */,
+				2248DB032004A5F900F2944C /* undo.c */,
+			);
+			name = ed;
+			path = text_cmds_grp/ed;
+			sourceTree = "<group>";
+		};
+		2248DB102004C5C500F2944C /* sed */ = {
+			isa = PBXGroup;
+			children = (
+				2248DB142004C5DB00F2944C /* compile.c */,
+				2248DB122004C5DB00F2944C /* main.c */,
+				2248DB112004C5DB00F2944C /* misc.c */,
+				2248DB132004C5DB00F2944C /* process.c */,
+			);
+			path = sed;
+			sourceTree = "<group>";
+		};
+		2248DB192004F7F100F2944C /* awk */ = {
+			isa = PBXGroup;
+			children = (
+				2248DB202004F82700F2944C /* b.c */,
+				2248DB1E2004F82600F2944C /* lex.c */,
+				2248DB1F2004F82600F2944C /* lib.c */,
+				2248DB242004F82700F2944C /* main.c */,
+				2248DB1D2004F82600F2944C /* parse.c */,
+				2248DB232004F82700F2944C /* proctab.c */,
+				2248DB1B2004F82600F2944C /* run.c */,
+				2248DB212004F82700F2944C /* tran.c */,
+				2248DB1A2004F82600F2944C /* ytab.c */,
+			);
+			path = awk;
 			sourceTree = "<group>";
 		};
 		22577D401FDB478E0050F312 /* libarchive_grp */ = {
@@ -2189,6 +2279,8 @@
 		22CF27B01FDB42F50087DDAD /* text_cmds_grp */ = {
 			isa = PBXGroup;
 			children = (
+				2248DB102004C5C500F2944C /* sed */,
+				2248DAFF2004A58600F2944C /* ed */,
 				22CF27B81FDB43070087DDAD /* cat */,
 				22CF27B11FDB43070087DDAD /* grep */,
 				22CF27BE1FDB43080087DDAD /* wc */,
@@ -2891,6 +2983,7 @@
 				2257824C1FDB4D390050F312 /* tool_cb_see.c in Sources */,
 				225781841FDB4D380050F312 /* http2.c in Sources */,
 				226378941FDB3EE400AE8827 /* ls.c in Sources */,
+				2248DB4520062EBB00F2944C /* process.c in Sources */,
 				2257822A1FDB4D390050F312 /* wildcard.c in Sources */,
 				225782061FDB4D390050F312 /* krb5_sspi.c in Sources */,
 				22577E981FDB47A90050F312 /* archive_write_set_compression_gzip.c in Sources */,
@@ -2906,17 +2999,21 @@
 				22577E641FDB47A90050F312 /* archive_read_data_into_fd.c in Sources */,
 				225782221FDB4D390050F312 /* polarssl_threadlock.c in Sources */,
 				22577E731FDB47A90050F312 /* archive_read_support_compression_gzip.c in Sources */,
+				2248DB4D20062EC000F2944C /* undo.c in Sources */,
 				2257828B1FDB4D390050F312 /* tool_writeenv.c in Sources */,
 				22577E6B1FDB47A90050F312 /* archive_read_open_fd.c in Sources */,
 				22CF27CC1FDB43080087DDAD /* wc.c in Sources */,
 				225781301FDB4D380050F312 /* connect.c in Sources */,
+				2248DB4620062EC000F2944C /* buf.c in Sources */,
 				22577E9E1FDB47A90050F312 /* archive_write_set_format_by_name.c in Sources */,
 				22577E941FDB47A90050F312 /* archive_write_open_memory.c in Sources */,
 				225781CA1FDB4D390050F312 /* rand.c in Sources */,
 				225781341FDB4D380050F312 /* cookie.c in Sources */,
 				2257813B1FDB4D380050F312 /* curl_des.c in Sources */,
 				22577E4B1FDB47A90050F312 /* line_reader.c in Sources */,
+				2248DB3B20062EB400F2944C /* lib.c in Sources */,
 				22577E901FDB47A90050F312 /* archive_write_disk_set_standard_lookup.c in Sources */,
+				2248DB3920062EB400F2944C /* b.c in Sources */,
 				2263788C1FDB3EE400AE8827 /* print.c in Sources */,
 				22CF27C61FDB43080087DDAD /* util.c in Sources */,
 				225781D11FDB4D390050F312 /* sendf.c in Sources */,
@@ -2927,6 +3024,7 @@
 				225781B01FDB4D380050F312 /* mprintf.c in Sources */,
 				22CF27951FDB3FDB0087DDAD /* date.c in Sources */,
 				225782801FDB4D390050F312 /* tool_sleep.c in Sources */,
+				2248DB4120062EB400F2944C /* ytab.c in Sources */,
 				225781631FDB4D380050F312 /* easy.c in Sources */,
 				225781FB1FDB4D390050F312 /* transfer.c in Sources */,
 				225781D51FDB4D390050F312 /* share.c in Sources */,
@@ -2964,6 +3062,7 @@
 				225781E31FDB4D390050F312 /* speedcheck.c in Sources */,
 				22577EA01FDB47A90050F312 /* archive_write_set_format_cpio_newc.c in Sources */,
 				2257816C1FDB4D380050F312 /* formdata.c in Sources */,
+				2248DB4220062EBB00F2944C /* compile.c in Sources */,
 				22577EA91FDB47A90050F312 /* filter_fork.c in Sources */,
 				225782761FDB4D390050F312 /* tool_panykey.c in Sources */,
 				2257825E1FDB4D390050F312 /* tool_getpass.c in Sources */,
@@ -2990,6 +3089,7 @@
 				225781881FDB4D380050F312 /* http_digest.c in Sources */,
 				22577F761FDB47B70050F312 /* bsdtar_windows.c in Sources */,
 				2257819A1FDB4D380050F312 /* ldap.c in Sources */,
+				2248DB3F20062EB400F2944C /* run.c in Sources */,
 				225781BF1FDB4D380050F312 /* openldap.c in Sources */,
 				225781651FDB4D380050F312 /* escape.c in Sources */,
 				225781731FDB4D380050F312 /* getinfo.c in Sources */,
@@ -3002,11 +3102,13 @@
 				2257812E1FDB4D380050F312 /* conncache.c in Sources */,
 				22577E4F1FDB47A90050F312 /* pathmatch.c in Sources */,
 				225781701FDB4D380050F312 /* ftplistparser.c in Sources */,
+				2248DB3D20062EB400F2944C /* parse.c in Sources */,
 				225782721FDB4D390050F312 /* tool_operate.c in Sources */,
 				225781C61FDB4D380050F312 /* pop3.c in Sources */,
 				22CF27911FDB3FDB0087DDAD /* env.c in Sources */,
 				225781F91FDB4D390050F312 /* timeval.c in Sources */,
 				22CF27C51FDB43080087DDAD /* queue.c in Sources */,
+				2248DB4720062EC000F2944C /* cbc.c in Sources */,
 				225782441FDB4D390050F312 /* tool_cb_dbg.c in Sources */,
 				22577E7D1FDB47A90050F312 /* archive_read_support_format_iso9660.c in Sources */,
 				226378A21FDB3EE400AE8827 /* stat.c in Sources */,
@@ -3020,6 +3122,7 @@
 				22577E831FDB47A90050F312 /* archive_string.c in Sources */,
 				22577E9B1FDB47A90050F312 /* archive_write_set_compression_xz.c in Sources */,
 				225782661FDB4D390050F312 /* tool_hugehelp.c in Sources */,
+				2248DB4020062EB400F2944C /* tran.c in Sources */,
 				2257818A1FDB4D380050F312 /* http_negotiate.c in Sources */,
 				22577E921FDB47A90050F312 /* archive_write_open_file.c in Sources */,
 				225781901FDB4D380050F312 /* idn_win32.c in Sources */,
@@ -3034,6 +3137,7 @@
 				22577E851FDB47A90050F312 /* archive_string_sprintf.c in Sources */,
 				226378801FDB3EE400AE8827 /* touch.c in Sources */,
 				225781771FDB4D380050F312 /* hash.c in Sources */,
+				2248DB4920062EC000F2944C /* io.c in Sources */,
 				226378B11FDB3EE400AE8827 /* zopen.c in Sources */,
 				22577E6C1FDB47A90050F312 /* archive_read_open_file.c in Sources */,
 				225781AA1FDB4D380050F312 /* md4.c in Sources */,
@@ -3041,11 +3145,13 @@
 				225782581FDB4D390050F312 /* tool_easysrc.c in Sources */,
 				225781C81FDB4D390050F312 /* progress.c in Sources */,
 				22577E9D1FDB47A90050F312 /* archive_write_set_format_ar.c in Sources */,
+				2248DB4A20062EC000F2944C /* main.c in Sources */,
 				22577E931FDB47A90050F312 /* archive_write_open_filename.c in Sources */,
 				225781971FDB4D380050F312 /* inet_pton.c in Sources */,
 				22577EA51FDB47A90050F312 /* archive_write_set_format_zip.c in Sources */,
 				2257815F1FDB4D380050F312 /* dict.c in Sources */,
 				225782071FDB4D390050F312 /* ntlm.c in Sources */,
+				2248DB3E20062EB400F2944C /* proctab.c in Sources */,
 				225781551FDB4D380050F312 /* curl_sasl.c in Sources */,
 				22577F791FDB47B70050F312 /* cmdline.c in Sources */,
 				22577F981FDB47B70050F312 /* write.c in Sources */,
@@ -3057,6 +3163,7 @@
 				22CF279C1FDB3FDB0087DDAD /* pwd.c in Sources */,
 				225782091FDB4D390050F312 /* ntlm_sspi.c in Sources */,
 				22CF27A01FDB3FDB0087DDAD /* fmt.c in Sources */,
+				2248DB4C20062EC000F2944C /* sub.c in Sources */,
 				226378A61FDB3EE400AE8827 /* chmod.c in Sources */,
 				225782021FDB4D390050F312 /* digest.c in Sources */,
 				22577E6D1FDB47A90050F312 /* archive_read_open_filename.c in Sources */,
@@ -3073,6 +3180,7 @@
 				225781BB1FDB4D380050F312 /* nwos.c in Sources */,
 				22577E991FDB47A90050F312 /* archive_write_set_compression_none.c in Sources */,
 				225781B61FDB4D380050F312 /* non-ascii.c in Sources */,
+				2248DB4820062EC000F2944C /* glbl.c in Sources */,
 				2257811F1FDB4D380050F312 /* asyn-thread.c in Sources */,
 				22CF279E1FDB3FDB0087DDAD /* uname.c in Sources */,
 				22577EA31FDB47A90050F312 /* archive_write_set_format_shar.c in Sources */,
@@ -3094,6 +3202,7 @@
 				225781FD1FDB4D390050F312 /* url.c in Sources */,
 				22577E961FDB47A90050F312 /* archive_write_set_compression_bzip2.c in Sources */,
 				22577E741FDB47A90050F312 /* archive_read_support_compression_none.c in Sources */,
+				2248DB4B20062EC000F2944C /* re.c in Sources */,
 				22577E9C1FDB47A90050F312 /* archive_write_set_format.c in Sources */,
 				22577E5D1FDB47A90050F312 /* archive_entry_strmode.c in Sources */,
 				2257817D1FDB4D380050F312 /* hostip.c in Sources */,
@@ -3104,6 +3213,7 @@
 				225782281FDB4D390050F312 /* warnless.c in Sources */,
 				225781361FDB4D380050F312 /* curl_addrinfo.c in Sources */,
 				22577E7E1FDB47A90050F312 /* archive_read_support_format_mtree.c in Sources */,
+				2248DB3C20062EB400F2944C /* main.c in Sources */,
 				2257811E1FDB4D380050F312 /* asyn-ares.c in Sources */,
 				2257819E1FDB4D380050F312 /* llist.c in Sources */,
 				22577E871FDB47A90050F312 /* archive_util.c in Sources */,
@@ -3159,6 +3269,8 @@
 				2257817F1FDB4D380050F312 /* hostip4.c in Sources */,
 				225781AB1FDB4D380050F312 /* md5.c in Sources */,
 				225782461FDB4D390050F312 /* tool_cb_hdr.c in Sources */,
+				2248DB4320062EBB00F2944C /* main.c in Sources */,
+				2248DB4420062EBB00F2944C /* misc.c in Sources */,
 				2257827D1FDB4D390050F312 /* tool_setopt.c in Sources */,
 				22577E781FDB47A90050F312 /* archive_read_support_compression_xz.c in Sources */,
 				225781E11FDB4D390050F312 /* socks_gssapi.c in Sources */,
@@ -3174,6 +3286,7 @@
 				225782841FDB4D390050F312 /* tool_urlglob.c in Sources */,
 				22CF27991FDB3FDB0087DDAD /* vary.c in Sources */,
 				22577E631FDB47A90050F312 /* archive_read.c in Sources */,
+				2248DB3A20062EB400F2944C /* lex.c in Sources */,
 				2263789F1FDB3EE400AE8827 /* humanize_number.c in Sources */,
 				225781211FDB4D380050F312 /* base64.c in Sources */,
 				22577F7C1FDB47B70050F312 /* read.c in Sources */,
@@ -3326,7 +3439,7 @@
 				OTHER_CFLAGS = "";
 				OTHER_LDFLAGS = (
 					"-L",
-					../blink/Frameworks/,
+					"../libssh2-for-iOS/",
 					"-F",
 					"../libssh2-for-iOS/",
 				);
@@ -3363,7 +3476,7 @@
 				OTHER_CFLAGS = "";
 				OTHER_LDFLAGS = (
 					"-L",
-					../blink/Frameworks/,
+					"../libssh2-for-iOS/",
 					"-F",
 					"../libssh2-for-iOS/",
 				);

--- a/Dependencies/ios_system/ios_system/ios_system.h
+++ b/Dependencies/ios_system/ios_system/ios_system.h
@@ -21,3 +21,4 @@ int ios_executable(char* inputCmd); // does this command exist? (executable file
 int ios_system(char* inputCmd); // execute this command (executable file or builtin command)
 
 char* commandsAsString();
+void initializeEnvironment();

--- a/Dependencies/ios_system/libarchive.patch
+++ b/Dependencies/ios_system/libarchive.patch
@@ -1,6 +1,6 @@
 diff -Naur libarchive-54/config.h libarchive/config.h
 --- libarchive-54/config.h	2012-04-17 04:07:27.000000000 +0200
-+++ libarchive/config.h	2017-12-09 00:12:52.000000000 +0100
++++ libarchive/config.h	2018-01-10 11:31:05.000000000 +0100
 @@ -222,7 +222,7 @@
  /* #undef HAVE_LIBEXPAT */
  
@@ -21,7 +21,7 @@ diff -Naur libarchive-54/config.h libarchive/config.h
  /* #undef HAVE_MD5INIT */
 diff -Naur libarchive-54/libarchive/libarchive/archive_read_support_format_iso9660.c libarchive/libarchive/libarchive/archive_read_support_format_iso9660.c
 --- libarchive-54/libarchive/libarchive/archive_read_support_format_iso9660.c	2012-09-21 00:45:16.000000000 +0200
-+++ libarchive/libarchive/libarchive/archive_read_support_format_iso9660.c	2017-12-09 00:12:52.000000000 +0100
++++ libarchive/libarchive/libarchive/archive_read_support_format_iso9660.c	2018-01-10 11:31:05.000000000 +0100
 @@ -2678,7 +2678,7 @@
  		parent_key = heap->files[parent]->key;
  		if (file_key >= parent_key) {
@@ -33,7 +33,7 @@ diff -Naur libarchive-54/libarchive/libarchive/archive_read_support_format_iso96
  		heap->files[hole] = heap->files[parent];
 diff -Naur libarchive-54/libarchive/libarchive/archive_util.c libarchive/libarchive/libarchive/archive_util.c
 --- libarchive-54/libarchive/libarchive/archive_util.c	2010-05-21 03:07:32.000000000 +0200
-+++ libarchive/libarchive/libarchive/archive_util.c	2017-12-09 00:12:52.000000000 +0100
++++ libarchive/libarchive/libarchive/archive_util.c	2018-01-10 11:31:05.000000000 +0100
 @@ -40,6 +40,7 @@
  #include "archive.h"
  #include "archive_private.h"
@@ -44,7 +44,7 @@ diff -Naur libarchive-54/libarchive/libarchive/archive_util.c libarchive/libarch
  /* These disappear in libarchive 3.0 */
 diff -Naur libarchive-54/libarchive/libarchive/archive_write_set_format_pax.c libarchive/libarchive/libarchive/archive_write_set_format_pax.c
 --- libarchive-54/libarchive/libarchive/archive_write_set_format_pax.c	2010-05-21 03:07:32.000000000 +0200
-+++ libarchive/libarchive/libarchive/archive_write_set_format_pax.c	2017-12-09 00:12:52.000000000 +0100
++++ libarchive/libarchive/libarchive/archive_write_set_format_pax.c	2018-01-10 11:31:05.000000000 +0100
 @@ -40,6 +40,7 @@
  #include "archive_entry.h"
  #include "archive_private.h"
@@ -55,7 +55,7 @@ diff -Naur libarchive-54/libarchive/libarchive/archive_write_set_format_pax.c li
  	uint64_t	entry_bytes_remaining;
 diff -Naur libarchive-54/libarchive/libarchive/archive_write_set_format_zip.c libarchive/libarchive/libarchive/archive_write_set_format_zip.c
 --- libarchive-54/libarchive/libarchive/archive_write_set_format_zip.c	2010-05-21 03:07:32.000000000 +0200
-+++ libarchive/libarchive/libarchive/archive_write_set_format_zip.c	2017-12-12 15:47:42.000000000 +0100
++++ libarchive/libarchive/libarchive/archive_write_set_format_zip.c	2018-01-10 11:31:05.000000000 +0100
 @@ -247,6 +247,7 @@
  	zip->len_buf = 65536;
  	zip->buf = malloc(zip->len_buf);
@@ -66,7 +66,7 @@ diff -Naur libarchive-54/libarchive/libarchive/archive_write_set_format_zip.c li
  	}
 diff -Naur libarchive-54/libarchive/libarchive/filter_fork.c libarchive/libarchive/libarchive/filter_fork.c
 --- libarchive-54/libarchive/libarchive/filter_fork.c	2010-05-21 03:07:32.000000000 +0200
-+++ libarchive/libarchive/libarchive/filter_fork.c	2017-12-09 00:12:52.000000000 +0100
++++ libarchive/libarchive/libarchive/filter_fork.c	2018-01-10 11:31:05.000000000 +0100
 @@ -24,6 +24,7 @@
   */
  
@@ -77,7 +77,7 @@ diff -Naur libarchive-54/libarchive/libarchive/filter_fork.c libarchive/libarchi
  #if defined(HAVE_PIPE) && defined(HAVE_FCNTL) && \
 diff -Naur libarchive-54/libarchive/libarchive_fe/err.c libarchive/libarchive/libarchive_fe/err.c
 --- libarchive-54/libarchive/libarchive_fe/err.c	2010-05-21 03:07:32.000000000 +0200
-+++ libarchive/libarchive/libarchive_fe/err.c	2017-12-09 00:12:52.000000000 +0100
++++ libarchive/libarchive/libarchive_fe/err.c	2018-01-10 11:31:05.000000000 +0100
 @@ -38,7 +38,8 @@
  #include <string.h>
  #endif
@@ -135,7 +135,7 @@ diff -Naur libarchive-54/libarchive/libarchive_fe/err.h libarchive/libarchive/li
 -#endif
 diff -Naur libarchive-54/libarchive/libarchive_fe/lafe_err.h libarchive/libarchive/libarchive_fe/lafe_err.h
 --- libarchive-54/libarchive/libarchive_fe/lafe_err.h	1970-01-01 01:00:00.000000000 +0100
-+++ libarchive/libarchive/libarchive_fe/lafe_err.h	2017-12-09 00:12:52.000000000 +0100
++++ libarchive/libarchive/libarchive_fe/lafe_err.h	2018-01-10 11:31:05.000000000 +0100
 @@ -0,0 +1,41 @@
 +/*-
 + * Copyright (c) 2009 Joerg Sonnenberger
@@ -180,7 +180,7 @@ diff -Naur libarchive-54/libarchive/libarchive_fe/lafe_err.h libarchive/libarchi
 +#endif
 diff -Naur libarchive-54/libarchive/libarchive_fe/line_reader.c libarchive/libarchive/libarchive_fe/line_reader.c
 --- libarchive-54/libarchive/libarchive_fe/line_reader.c	2010-05-21 03:07:32.000000000 +0200
-+++ libarchive/libarchive/libarchive_fe/line_reader.c	2017-12-09 00:12:52.000000000 +0100
++++ libarchive/libarchive/libarchive_fe/line_reader.c	2018-01-10 11:31:05.000000000 +0100
 @@ -32,7 +32,7 @@
  #include <stdlib.h>
  #include <string.h>
@@ -192,7 +192,7 @@ diff -Naur libarchive-54/libarchive/libarchive_fe/line_reader.c libarchive/libar
  #if defined(_WIN32) && !defined(__CYGWIN__) && !defined(__BORLANDC__)
 diff -Naur libarchive-54/libarchive/libarchive_fe/matching.c libarchive/libarchive/libarchive_fe/matching.c
 --- libarchive-54/libarchive/libarchive_fe/matching.c	2010-05-21 03:07:32.000000000 +0200
-+++ libarchive/libarchive/libarchive_fe/matching.c	2017-12-09 00:12:52.000000000 +0100
++++ libarchive/libarchive/libarchive_fe/matching.c	2018-01-10 11:31:05.000000000 +0100
 @@ -36,7 +36,7 @@
  #include <string.h>
  #endif
@@ -204,7 +204,7 @@ diff -Naur libarchive-54/libarchive/libarchive_fe/matching.c libarchive/libarchi
  #include "pathmatch.h"
 diff -Naur libarchive-54/libarchive/tar/bsdtar.c libarchive/libarchive/tar/bsdtar.c
 --- libarchive-54/libarchive/tar/bsdtar.c	2015-08-20 00:50:01.000000000 +0200
-+++ libarchive/libarchive/tar/bsdtar.c	2017-12-13 15:55:52.000000000 +0100
++++ libarchive/libarchive/tar/bsdtar.c	2018-01-10 11:31:05.000000000 +0100
 @@ -70,7 +70,8 @@
  #include <copyfile.h>
  
@@ -238,7 +238,7 @@ diff -Naur libarchive-54/libarchive/tar/bsdtar.c libarchive/libarchive/tar/bsdta
  	{ /* Catch SIGINFO and SIGUSR1, if they exist. */
 diff -Naur libarchive-54/libarchive/tar/cmdline.c libarchive/libarchive/tar/cmdline.c
 --- libarchive-54/libarchive/tar/cmdline.c	2010-05-21 03:07:32.000000000 +0200
-+++ libarchive/libarchive/tar/cmdline.c	2017-12-13 16:01:40.000000000 +0100
++++ libarchive/libarchive/tar/cmdline.c	2018-01-10 11:31:05.000000000 +0100
 @@ -41,7 +41,7 @@
  #endif
  
@@ -273,7 +273,7 @@ diff -Naur libarchive-54/libarchive/tar/cmdline.c libarchive/libarchive/tar/cmdl
  	int opt = '?';
 diff -Naur libarchive-54/libarchive/tar/getdate.c libarchive/libarchive/tar/getdate.c
 --- libarchive-54/libarchive/tar/getdate.c	2010-05-21 03:07:32.000000000 +0200
-+++ libarchive/libarchive/tar/getdate.c	2017-12-09 00:28:42.000000000 +0100
++++ libarchive/libarchive/tar/getdate.c	2018-01-10 11:31:05.000000000 +0100
 @@ -37,6 +37,7 @@
  #include <stdlib.h>
  #include <string.h>
@@ -284,7 +284,7 @@ diff -Naur libarchive-54/libarchive/tar/getdate.c libarchive/libarchive/tar/getd
  time_t get_date(time_t now, char *);
 diff -Naur libarchive-54/libarchive/tar/read.c libarchive/libarchive/tar/read.c
 --- libarchive-54/libarchive/tar/read.c	2016-08-27 00:40:00.000000000 +0200
-+++ libarchive/libarchive/tar/read.c	2017-12-09 00:31:13.000000000 +0100
++++ libarchive/libarchive/tar/read.c	2018-01-10 11:31:05.000000000 +0100
 @@ -79,7 +79,7 @@
  #endif /* HAVE_QUARANTINE */
  
@@ -296,7 +296,7 @@ diff -Naur libarchive-54/libarchive/tar/read.c libarchive/libarchive/tar/read.c
  	struct bsdtar *bsdtar;
 diff -Naur libarchive-54/libarchive/tar/subst.c libarchive/libarchive/tar/subst.c
 --- libarchive-54/libarchive/tar/subst.c	2010-05-21 03:07:32.000000000 +0200
-+++ libarchive/libarchive/tar/subst.c	2017-12-09 00:31:00.000000000 +0100
++++ libarchive/libarchive/tar/subst.c	2018-01-10 11:31:05.000000000 +0100
 @@ -38,7 +38,7 @@
  #define	REG_BASIC 0
  #endif
@@ -308,7 +308,7 @@ diff -Naur libarchive-54/libarchive/tar/subst.c libarchive/libarchive/tar/subst.
  	struct subst_rule *next;
 diff -Naur libarchive-54/libarchive/tar/util.c libarchive/libarchive/tar/util.c
 --- libarchive-54/libarchive/tar/util.c	2016-11-15 22:44:15.000000000 +0100
-+++ libarchive/libarchive/tar/util.c	2017-12-09 00:30:14.000000000 +0100
++++ libarchive/libarchive/tar/util.c	2018-01-10 11:31:05.000000000 +0100
 @@ -60,7 +60,7 @@
  #endif
  
@@ -320,7 +320,7 @@ diff -Naur libarchive-54/libarchive/tar/util.c libarchive/libarchive/tar/util.c
  static const char *strip_components(const char *path, int elements);
 diff -Naur libarchive-54/libarchive/tar/write.c libarchive/libarchive/tar/write.c
 --- libarchive-54/libarchive/tar/write.c	2010-05-21 03:07:32.000000000 +0200
-+++ libarchive/libarchive/tar/write.c	2017-12-09 00:30:50.000000000 +0100
++++ libarchive/libarchive/tar/write.c	2018-01-10 11:31:05.000000000 +0100
 @@ -88,9 +88,10 @@
  #include <libgen.h>
  #include <paths.h>

--- a/Dependencies/ios_system/shell_cmds.patch
+++ b/Dependencies/ios_system/shell_cmds.patch
@@ -1,6 +1,6 @@
 diff -Naur shell_cmds-203/date/date.c shell_cmds/date/date.c
 --- shell_cmds-203/date/date.c	2015-11-07 23:19:55.000000000 +0100
-+++ shell_cmds/date/date.c	2017-12-12 23:58:22.000000000 +0100
++++ shell_cmds/date/date.c	2018-01-10 11:31:01.000000000 +0100
 @@ -47,7 +47,7 @@
  #include <sys/stat.h>
  
@@ -10,7 +10,7 @@ diff -Naur shell_cmds-203/date/date.c shell_cmds/date/date.c
  #include <locale.h>
  #include <stdio.h>
  #include <stdlib.h>
-@@ -57,13 +57,14 @@
+@@ -57,13 +57,15 @@
  #include <utmpx.h>
  
  #ifdef __APPLE__
@@ -23,11 +23,12 @@ diff -Naur shell_cmds-203/date/date.c shell_cmds/date/date.c
  
  #include "extern.h"
  #include "vary.h"
++#include <errno.h>
 +#include "ios_error.h"
  
  #ifndef	TM_YEAR_BASE
  #define	TM_YEAR_BASE	1900
-@@ -84,7 +85,7 @@
+@@ -84,7 +86,7 @@
  static const char *rfc2822_format = "%a, %d %b %Y %T %z";
  
  int
@@ -36,7 +37,7 @@ diff -Naur shell_cmds-203/date/date.c shell_cmds/date/date.c
  {
  	struct timezone tz;
  	int ch, rflag;
-@@ -107,6 +108,7 @@
+@@ -107,6 +109,7 @@
  	tz.tz_dsttime = tz.tz_minuteswest = 0;
  	rflag = 0;
  	jflag = nflag = Rflag = 0;
@@ -44,7 +45,7 @@ diff -Naur shell_cmds-203/date/date.c shell_cmds/date/date.c
  	set_timezone = 0;
  	while ((ch = getopt(argc, argv, "d:f:jnRr:t:uv:")) != -1)
  		switch((char)ch) {
-@@ -161,11 +163,17 @@
+@@ -161,11 +164,17 @@
  	 * If -d or -t, set the timezone or daylight savings time; this
  	 * doesn't belong here; the kernel should not know about either.
  	 */
@@ -55,30 +56,30 @@ diff -Naur shell_cmds-203/date/date.c shell_cmds/date/date.c
 -		err(1, "time");
 +    if (set_timezone && settimeofday(NULL, &tz) != 0) {
 +		// err(1, "settimeofday (timezone)");
-+        fprintf(stderr, "date: settimeofday (timezone)\n");
++        fprintf(stderr, "date: settimeofday (timezone): %s\n", strerror(errno));
 +        pthread_exit(NULL);
 +    }
 +
 +    if (!rflag && time(&tval) == -1) {
 +		// err(1, "time");
-+        fprintf(stderr, "date: time\n");
++        fprintf(stderr, "date: time: %s\n", strerror(errno));
 +        pthread_exit(NULL);
 +    }
  
  	format = "%+";
  
-@@ -191,7 +199,9 @@
+@@ -191,7 +200,9 @@
  	/* 7999711 */
  	struct tm *ltp = localtime(&tval);
  	if (ltp == NULL) {
 -		err(1, "localtime");
 +		// err(1, "localtime");
-+        fprintf(stderr, "date: localtime\n");
++        fprintf(stderr, "date: localtime: %s\n", strerror(errno));
 +        pthread_exit(NULL);
  	}
  	lt = *ltp;
  #else
-@@ -215,8 +225,11 @@
+@@ -215,8 +226,11 @@
  
  	(void)strftime(buf, sizeof(buf), format, &lt);
  	(void)printf("%s\n", buf);
@@ -86,13 +87,13 @@ diff -Naur shell_cmds-203/date/date.c shell_cmds/date/date.c
 -		err(1, "stdout");
 +    if (fflush(stdout)) {
 +		// err(1, "stdout");
-+        fprintf(stderr, "date: stdout\n");
++        fprintf(stderr, "date: stdout: %s\n", strerror(errno));
 +        pthread_exit(NULL);
 +    }
  	/*
  	 * If date/time could not be set/notified in the other hosts as
  	 * determined by netsetval(), a return value 2 is set, which is
-@@ -319,19 +332,25 @@
+@@ -319,19 +333,25 @@
  	}
  
  	/* convert broken-down time to GMT clock time */
@@ -117,13 +118,13 @@ diff -Naur shell_cmds-203/date/date.c shell_cmds/date/date.c
 -				err(1, "settimeofday (timeval)");
 +            if (settimeofday(&tv, NULL) != 0) {
 +				// err(1, "settimeofday (timeval)");
-+                fprintf(stderr, "date: settimeofday (timeval)\n");
++                fprintf(stderr, "date: settimeofday (timeval): %s\n", strerror(errno));
 +                pthread_exit(NULL);
 +            }
  			utx.ut_type = NEW_TIME;
  			(void)gettimeofday(&utx.ut_tv, NULL);
  			pututxline(&utx);
-@@ -346,7 +365,8 @@
+@@ -346,7 +366,8 @@
  static void
  badformat(void)
  {
@@ -135,8 +136,8 @@ diff -Naur shell_cmds-203/date/date.c shell_cmds/date/date.c
  
 diff -Naur shell_cmds-203/date/vary.c shell_cmds/date/vary.c
 --- shell_cmds-203/date/vary.c	2015-11-07 23:19:55.000000000 +0100
-+++ shell_cmds/date/vary.c	2017-12-12 23:58:22.000000000 +0100
-@@ -27,11 +27,13 @@
++++ shell_cmds/date/vary.c	2018-01-10 11:31:01.000000000 +0100
+@@ -27,11 +27,14 @@
  #include <sys/cdefs.h>
  __FBSDID("$FreeBSD$");
  
@@ -147,11 +148,12 @@ diff -Naur shell_cmds-203/date/vary.c shell_cmds/date/vary.c
  #include <stdlib.h>
 +#include <stdio.h>
  #include "vary.h"
++#include <errno.h>
 +#include "ios_error.h"
  
  struct trans {
    int val;
-@@ -92,8 +94,11 @@
+@@ -92,8 +95,11 @@
    } else
      nextp = &result;
  
@@ -159,7 +161,7 @@ diff -Naur shell_cmds-203/date/vary.c shell_cmds/date/vary.c
 -    err(1, "malloc");
 +    if ((*nextp = (struct vary *)malloc(sizeof(struct vary))) == NULL) {
 +        // err(1, "malloc");
-+        fprintf(stderr, "date: malloc\n");
++        fprintf(stderr, "date: malloc: %s\n", strerror(errno));
 +        pthread_exit(NULL);
 +    }
    (*nextp)->arg = arg;
@@ -167,7 +169,7 @@ diff -Naur shell_cmds-203/date/vary.c shell_cmds/date/vary.c
    return result;
 diff -Naur shell_cmds-203/env/env.c shell_cmds/env/env.c
 --- shell_cmds-203/env/env.c	2014-08-05 00:47:11.000000000 +0200
-+++ shell_cmds/env/env.c	2017-12-12 23:58:22.000000000 +0100
++++ shell_cmds/env/env.c	2018-01-10 11:31:01.000000000 +0100
 @@ -42,7 +42,7 @@
  #include <sys/cdefs.h>
  __FBSDID("$FreeBSD$");
@@ -210,7 +212,7 @@ diff -Naur shell_cmds-203/env/env.c shell_cmds/env/env.c
 -				err(EXIT_FAILURE, "unsetenv %s", optarg);
 +            if (rtrn == -1) {
 +				// err(EXIT_FAILURE, "unsetenv %s", optarg);
-+                fprintf(stderr, "unsetenv %s\n", optarg);
++                fprintf(stderr, "unsetenv %s: %s\n", optarg, strerror(errno));
 +                pthread_exit(NULL);
 +            }
  			break;
@@ -224,7 +226,7 @@ diff -Naur shell_cmds-203/env/env.c shell_cmds/env/env.c
 -			err(EXIT_FAILURE, "setenv %s", *argv);
 +        if (rtrn == -1) {
 +			// err(EXIT_FAILURE, "setenv %s", *argv);
-+            fprintf(stderr, "setenv %s\n", *argv);
++            fprintf(stderr, "setenv %s: %s\n", *argv, strerror(errno));
 +            pthread_exit(NULL);
 +        }
  	}
@@ -237,7 +239,7 @@ diff -Naur shell_cmds-203/env/env.c shell_cmds/env/env.c
 -		execvp(*argv, argv);
 -		err(errno == ENOENT ? 127 : 126, "%s", *argv);
 +        execvp(*argv, argv);
-+        fprintf(stderr, "env: %s\n", *argv);
++        fprintf(stderr, "env: %s: %s\n", *argv, strerror(errno));
 +        pthread_exit(NULL);
 +		// err(errno == ENOENT ? 127 : 126, "%s", *argv);
  	}
@@ -245,7 +247,7 @@ diff -Naur shell_cmds-203/env/env.c shell_cmds/env/env.c
  		(void)printf("%s\n", *ep);
 diff -Naur shell_cmds-203/env/envopts.c shell_cmds/env/envopts.c
 --- shell_cmds-203/env/envopts.c	2014-08-05 00:47:11.000000000 +0200
-+++ shell_cmds/env/envopts.c	2017-12-12 23:58:22.000000000 +0100
++++ shell_cmds/env/envopts.c	2018-01-10 11:31:01.000000000 +0100
 @@ -33,7 +33,7 @@
  
  #include <sys/stat.h>
@@ -269,7 +271,7 @@ diff -Naur shell_cmds-203/env/envopts.c shell_cmds/env/envopts.c
  		errno = ENOENT;
 -		err(127, "%s", filename);
 +		// err(127, "%s", filename);
-+        fprintf(stderr, "env: %s\n", filename);
++        fprintf(stderr, "env: %s: %s\n", filename, strerror(errno));
 +        pthread_exit(NULL);
  	}
  	*argv = strdup(candidate);
@@ -334,7 +336,7 @@ diff -Naur shell_cmds-203/env/envopts.c shell_cmds/env/envopts.c
  	 * We now know we have a valid environment variable name, so update
 diff -Naur shell_cmds-203/id/id.c shell_cmds/id/id.c
 --- shell_cmds-203/id/id.c	2014-02-18 21:44:21.000000000 +0100
-+++ shell_cmds/id/id.c	2017-12-12 23:58:22.000000000 +0100
++++ shell_cmds/id/id.c	2018-01-10 11:31:01.000000000 +0100
 @@ -54,7 +54,7 @@
  #include <bsm/audit.h>
  #endif
@@ -401,7 +403,7 @@ diff -Naur shell_cmds-203/id/id.c shell_cmds/id/id.c
 -			err(1, "getlogin");
 +        if ((login = getlogin()) == NULL) {
 +			// err(1, "getlogin");
-+            fprintf(stderr, "id: getlogin\n");
++            fprintf(stderr, "id: getlogin: %s\n", strerror(errno));
 +            pthread_exit(NULL);
 +        }
  
@@ -412,7 +414,7 @@ diff -Naur shell_cmds-203/id/id.c shell_cmds/id/id.c
  #ifdef __APPLE__
  	if (ngroups < 0)
 -		warn("failed to retrieve group list");
-+        fprintf(stderr, "id: failed to retrieve group list\n");
++        fprintf(stderr, "id: failed to retrieve group list: %s\n", strerror(errno));
 +        // warn("failed to retrieve group list");
  #endif
  
@@ -425,7 +427,7 @@ diff -Naur shell_cmds-203/id/id.c shell_cmds/id/id.c
 -		err(1, "getaudit");
 +    if (getaudit_addr(&auditinfo, sizeof(auditinfo)) < 0) {
 +		// err(1, "getaudit");
-+        fprintf(stderr, "id: getaudit\n");
++        fprintf(stderr, "id: getaudit: %s\n", strerror(errno));
 +        pthread_exit(NULL);
 +    }
  	printf("auid=%d\n", auditinfo.ai_auid);
@@ -439,7 +441,7 @@ diff -Naur shell_cmds-203/id/id.c shell_cmds/id/id.c
 -			err(1, "getpwuid");
 +        if ((pw = getpwuid(getuid())) == NULL) {
 +			// err(1, "getpwuid");
-+            fprintf(stderr, "id: getpwuid\n");
++            fprintf(stderr, "id: getpwuid: %s\n", strerror(errno));
 +            pthread_exit(NULL);
 +        }
  	}
@@ -451,7 +453,7 @@ diff -Naur shell_cmds-203/id/id.c shell_cmds/id/id.c
  #ifdef __APPLE__
 -	errx(1, "-M unsupported");
 +	// errx(1, "-M unsupported");
-+    fprintf(stderr, "-M unsupported");
++    fprintf(stderr, "id: -M unsupported");
 +    pthread_exit(NULL);
  #else /* !__APPLE__ */
  	char *string;
@@ -484,7 +486,7 @@ diff -Naur shell_cmds-203/id/id.c shell_cmds/id/id.c
 -			err(1, "getpwuid");
 +        if ((pw = getpwuid(getuid())) == NULL) {
 +			// err(1, "getpwuid");
-+            fprintf(stderr, "id: getpwuid\n");
++            fprintf(stderr, "id: getpwuid: %s\n", strerror(errno));
 +            pthread_exit(NULL);
 +        }
  	}
@@ -492,7 +494,7 @@ diff -Naur shell_cmds-203/id/id.c shell_cmds/id/id.c
  	(void)printf("%s:%s:%d:%d:%s:%ld:%ld:%s:%s:%s\n", pw->pw_name,
 diff -Naur shell_cmds-203/printenv/printenv.c shell_cmds/printenv/printenv.c
 --- shell_cmds-203/printenv/printenv.c	2014-08-05 00:47:11.000000000 +0200
-+++ shell_cmds/printenv/printenv.c	2017-12-09 00:12:42.000000000 +0100
++++ shell_cmds/printenv/printenv.c	2018-01-10 11:31:01.000000000 +0100
 @@ -48,8 +48,9 @@
  #include <stdio.h>
  #include <string.h>
@@ -529,8 +531,8 @@ diff -Naur shell_cmds-203/printenv/printenv.c shell_cmds/printenv/printenv.c
  	(void)fprintf(stderr, "usage: printenv [name]\n");
 diff -Naur shell_cmds-203/pwd/pwd.c shell_cmds/pwd/pwd.c
 --- shell_cmds-203/pwd/pwd.c	2006-09-12 00:14:13.000000000 +0200
-+++ shell_cmds/pwd/pwd.c	2017-12-12 23:58:22.000000000 +0100
-@@ -45,21 +45,23 @@
++++ shell_cmds/pwd/pwd.c	2018-01-10 11:31:01.000000000 +0100
+@@ -45,21 +45,24 @@
  #include <sys/stat.h>
  #include <sys/types.h>
  
@@ -540,6 +542,7 @@ diff -Naur shell_cmds-203/pwd/pwd.c shell_cmds/pwd/pwd.c
  #include <stdio.h>
  #include <stdlib.h>
  #include <unistd.h>
++#include <string.h>
 +#include "ios_error.h"
  
  static char *getcwd_logical(void);
@@ -557,7 +560,7 @@ diff -Naur shell_cmds-203/pwd/pwd.c shell_cmds/pwd/pwd.c
  
  	// 4207130
  	physical = 0;
-@@ -91,13 +93,16 @@
+@@ -91,13 +94,16 @@
  	if ((!physical && (p = getcwd_logical()) != NULL) ||
  	    ((physical || errno == ENOENT) && (p = getcwd(NULL, 0)) != NULL))
  		printf("%s\n", p);
@@ -565,7 +568,7 @@ diff -Naur shell_cmds-203/pwd/pwd.c shell_cmds/pwd/pwd.c
 -		err(1, ".");
 +    else {
 +		// err(1, ".");
-+        fprintf(stderr, "pwd: .\n");
++        fprintf(stderr, "pwd: .: %s\n", strerror(errno));
 +        pthread_exit(NULL);
 +    }
  
@@ -579,8 +582,8 @@ diff -Naur shell_cmds-203/pwd/pwd.c shell_cmds/pwd/pwd.c
  
 diff -Naur shell_cmds-203/uname/uname.c shell_cmds/uname/uname.c
 --- shell_cmds-203/uname/uname.c	2013-09-26 01:55:54.000000000 +0200
-+++ shell_cmds/uname/uname.c	2017-12-12 23:58:22.000000000 +0100
-@@ -42,21 +42,22 @@
++++ shell_cmds/uname/uname.c	2018-01-10 11:31:01.000000000 +0100
+@@ -42,21 +42,23 @@
  #include <stdio.h>
  #include <stdlib.h>
  #include <unistd.h>
@@ -592,6 +595,7 @@ diff -Naur shell_cmds-203/uname/uname.c shell_cmds/uname/uname.c
  
  #include <sys/sysctl.h>
  #include <sys/utsname.h>
++#include <errno.h>
 +#include "ios_error.h"
  
  #ifdef __APPLE__
@@ -607,7 +611,7 @@ diff -Naur shell_cmds-203/uname/uname.c shell_cmds/uname/uname.c
  static void usage __P((void));
  
  /* Note that PRINT_MACHINE_ARCH is excluded from PRINT_ALL! */
-@@ -70,7 +71,7 @@
+@@ -70,7 +72,7 @@
      (PRINT_SYSNAME|PRINT_NODENAME|PRINT_RELEASE|PRINT_VERSION|PRINT_MACHINE)
  
  int
@@ -616,7 +620,7 @@ diff -Naur shell_cmds-203/uname/uname.c shell_cmds/uname/uname.c
  	int argc;
  	char **argv;
  {
-@@ -81,7 +82,8 @@
+@@ -81,7 +83,8 @@
  	int c;
  	int space = 0;
  	int print_mask = 0;
@@ -626,20 +630,20 @@ diff -Naur shell_cmds-203/uname/uname.c shell_cmds/uname/uname.c
  	(void)setlocale(LC_ALL, "");
  
  	while ((c = getopt(argc,argv,"amnprsv")) != -1) {
-@@ -128,7 +130,9 @@
+@@ -128,7 +131,9 @@
  	}
  
  	if (uname(&u) != 0) {
 -		err(EXIT_FAILURE, "uname");
 +		// err(EXIT_FAILURE, "uname");
-+        fprintf(stderr, "uname\n");
++        fprintf(stderr, "uname: %s\n", strerror(errno));
 +        pthread_exit(NULL);
  		/* NOTREACHED */
  	}
  #ifndef __APPLE__
 diff -Naur shell_cmds-203/w/fmt.c shell_cmds/w/fmt.c
 --- shell_cmds-203/w/fmt.c	2007-01-19 02:15:36.000000000 +0100
-+++ shell_cmds/w/fmt.c	2017-12-12 23:58:22.000000000 +0100
++++ shell_cmds/w/fmt.c	2018-01-10 11:31:01.000000000 +0100
 @@ -39,13 +39,13 @@
  #include <sys/time.h>
  #include <sys/resource.h>
@@ -679,7 +683,7 @@ diff -Naur shell_cmds-203/w/fmt.c shell_cmds/w/fmt.c
  	if (*argv == 0) {
 diff -Naur shell_cmds-203/w/proc_compare.c shell_cmds/w/proc_compare.c
 --- shell_cmds-203/w/proc_compare.c	2007-01-19 02:15:36.000000000 +0100
-+++ shell_cmds/w/proc_compare.c	2017-12-09 00:12:42.000000000 +0100
++++ shell_cmds/w/proc_compare.c	2018-01-10 11:31:01.000000000 +0100
 @@ -38,13 +38,15 @@
  __FBSDID("$FreeBSD: src/usr.bin/w/proc_compare.c,v 1.9 2004/04/14 09:34:17 bde Exp $");
  #endif
@@ -699,7 +703,7 @@ diff -Naur shell_cmds-203/w/proc_compare.c shell_cmds/w/proc_compare.c
  
 diff -Naur shell_cmds-203/w/w.c shell_cmds/w/w.c
 --- shell_cmds-203/w/w.c	2007-10-03 11:55:12.000000000 +0200
-+++ shell_cmds/w/w.c	2017-12-12 23:58:22.000000000 +0100
++++ shell_cmds/w/w.c	2018-01-10 11:31:01.000000000 +0100
 @@ -50,15 +50,16 @@
   * This program is similar to the systat command on Tenex/Tops 10/20
   *
@@ -758,7 +762,7 @@ diff -Naur shell_cmds-203/w/w.c shell_cmds/w/w.c
   */
 -struct	entry {
 -	struct	entry *next;
-+struct	utmp_entry {
++static struct	utmp_entry {
 +	struct	utmp_entry *next;
  #if HAVE_UTMPX
  	struct	utmpx utmp;
@@ -811,7 +815,7 @@ diff -Naur shell_cmds-203/w/w.c shell_cmds/w/w.c
 -		err(1, "%s", _PATH_UTMP);
 +    if ((ut = fopen(_PATH_UTMP, "r")) == NULL) {
 +		// err(1, "%s", _PATH_UTMP);
-+        fprintf(stderr, "w: %s\n", _PATH_UTMP);
++        fprintf(stderr, "w: %s: %s\n", _PATH_UTMP, strerror(errno));
 +        pthread_exit(NULL);
 +    }
  #endif
@@ -839,19 +843,23 @@ diff -Naur shell_cmds-203/w/w.c shell_cmds/w/w.c
 -		err(1, "%s", kvm_geterr(kd));
 +    if ((kp = kvm_getprocs(kd, KERN_PROC_ALL, 0, &nentries)) == NULL) {
 +		// err(1, "%s", kvm_geterr(kd));
-+        fprintf(stderr, "w: %s\n", kvm_geterr(kd));
++        fprintf(stderr, "w: %s: %s\n", kvm_geterr(kd), strerror(errno));
 +        pthread_exit(NULL);
 +    }
  #else
  	mib[0] = CTL_KERN;
  	mib[1] = KERN_PROC;
-@@ -485,11 +501,12 @@
+@@ -484,12 +500,15 @@
+ #else
  		w_getargv();
  #endif /* HAVE_KVM */
- 		if (ep->args == NULL)
+-		if (ep->args == NULL)
 -			err(1, NULL);
++        if (ep->args == NULL) {
++            fprintf(stderr, "w: %s\n", strerror(errno));
 +            pthread_exit(NULL);
 +			// err(1, NULL);
++        }
  	}
  	/* sort by idle time */
  	if (sortidle && ehead != NULL) {
@@ -860,12 +868,12 @@ diff -Naur shell_cmds-203/w/w.c shell_cmds/w/w.c
  
  		from = ehead;
  		ehead = NULL;
-@@ -674,7 +691,8 @@
+@@ -674,7 +693,8 @@
  	if (stat(ttybuf, &sb) == 0) {
  		return (&sb);
  	} else {
 -		warn("%s", ttybuf);
-+        fprintf(stderr, "w: %s\n", ttybuf);
++        fprintf(stderr, "w: %s: %s\n", ttybuf, strerror(errno));
 +        // warn("%s", ttybuf);
  		return (NULL);
  	}

--- a/Dependencies/ios_system/shell_cmds/date/date.c
+++ b/Dependencies/ios_system/shell_cmds/date/date.c
@@ -64,6 +64,7 @@ __FBSDID("$FreeBSD$");
 
 #include "extern.h"
 #include "vary.h"
+#include <errno.h>
 #include "ios_error.h"
 
 #ifndef	TM_YEAR_BASE
@@ -165,13 +166,13 @@ date_main(int argc, char *argv[])
 	 */
     if (set_timezone && settimeofday(NULL, &tz) != 0) {
 		// err(1, "settimeofday (timezone)");
-        fprintf(stderr, "date: settimeofday (timezone)\n");
+        fprintf(stderr, "date: settimeofday (timezone): %s\n", strerror(errno));
         pthread_exit(NULL);
     }
 
     if (!rflag && time(&tval) == -1) {
 		// err(1, "time");
-        fprintf(stderr, "date: time\n");
+        fprintf(stderr, "date: time: %s\n", strerror(errno));
         pthread_exit(NULL);
     }
 
@@ -200,7 +201,7 @@ date_main(int argc, char *argv[])
 	struct tm *ltp = localtime(&tval);
 	if (ltp == NULL) {
 		// err(1, "localtime");
-        fprintf(stderr, "date: localtime\n");
+        fprintf(stderr, "date: localtime: %s\n", strerror(errno));
         pthread_exit(NULL);
 	}
 	lt = *ltp;
@@ -227,7 +228,7 @@ date_main(int argc, char *argv[])
 	(void)printf("%s\n", buf);
     if (fflush(stdout)) {
 		// err(1, "stdout");
-        fprintf(stderr, "date: stdout\n");
+        fprintf(stderr, "date: stdout: %s\n", strerror(errno));
         pthread_exit(NULL);
     }
 	/*
@@ -348,7 +349,7 @@ setthetime(const char *fmt, const char *p, int jflag, int nflag)
 			tv.tv_usec = 0;
             if (settimeofday(&tv, NULL) != 0) {
 				// err(1, "settimeofday (timeval)");
-                fprintf(stderr, "date: settimeofday (timeval)\n");
+                fprintf(stderr, "date: settimeofday (timeval): %s\n", strerror(errno));
                 pthread_exit(NULL);
             }
 			utx.ut_type = NEW_TIME;

--- a/Dependencies/ios_system/shell_cmds/date/vary.c
+++ b/Dependencies/ios_system/shell_cmds/date/vary.c
@@ -33,6 +33,7 @@ __FBSDID("$FreeBSD$");
 #include <stdlib.h>
 #include <stdio.h>
 #include "vary.h"
+#include <errno.h>
 #include "ios_error.h"
 
 struct trans {
@@ -96,7 +97,7 @@ vary_append(struct vary *v, char *arg)
 
     if ((*nextp = (struct vary *)malloc(sizeof(struct vary))) == NULL) {
         // err(1, "malloc");
-        fprintf(stderr, "date: malloc\n");
+        fprintf(stderr, "date: malloc: %s\n", strerror(errno));
         pthread_exit(NULL);
     }
   (*nextp)->arg = arg;

--- a/Dependencies/ios_system/shell_cmds/env/env.c
+++ b/Dependencies/ios_system/shell_cmds/env/env.c
@@ -91,7 +91,7 @@ env_main(int argc, char **argv)
 			rtrn = unsetenv(optarg);
             if (rtrn == -1) {
 				// err(EXIT_FAILURE, "unsetenv %s", optarg);
-                fprintf(stderr, "unsetenv %s\n", optarg);
+                fprintf(stderr, "unsetenv %s: %s\n", optarg, strerror(errno));
                 pthread_exit(NULL);
             }
 			break;
@@ -119,7 +119,7 @@ env_main(int argc, char **argv)
 		*p = '=';
         if (rtrn == -1) {
 			// err(EXIT_FAILURE, "setenv %s", *argv);
-            fprintf(stderr, "setenv %s\n", *argv);
+            fprintf(stderr, "setenv %s: %s\n", *argv, strerror(errno));
             pthread_exit(NULL);
         }
 	}
@@ -135,7 +135,7 @@ env_main(int argc, char **argv)
 				sleep(1);
 		}
         execvp(*argv, argv);
-        fprintf(stderr, "env: %s\n", *argv);
+        fprintf(stderr, "env: %s: %s\n", *argv, strerror(errno));
         pthread_exit(NULL);
 		// err(errno == ENOENT ? 127 : 126, "%s", *argv);
 	}

--- a/Dependencies/ios_system/shell_cmds/env/envopts.c
+++ b/Dependencies/ios_system/shell_cmds/env/envopts.c
@@ -127,7 +127,7 @@ search_paths(char *path, char **argv)
 	if (fqname == NULL) {
 		errno = ENOENT;
 		// err(127, "%s", filename);
-        fprintf(stderr, "env: %s\n", filename);
+        fprintf(stderr, "env: %s: %s\n", filename, strerror(errno));
         pthread_exit(NULL);
 	}
 	*argv = strdup(candidate);

--- a/Dependencies/ios_system/shell_cmds/id/id.c
+++ b/Dependencies/ios_system/shell_cmds/id/id.c
@@ -248,7 +248,7 @@ pretty(struct passwd *pw)
 	} else {
         if ((login = getlogin()) == NULL) {
 			// err(1, "getlogin");
-            fprintf(stderr, "id: getlogin\n");
+            fprintf(stderr, "id: getlogin: %s\n", strerror(errno));
             pthread_exit(NULL);
         }
 
@@ -326,7 +326,7 @@ id_print(struct passwd *pw, int use_ggl, int p_euid, int p_egid)
 
 #ifdef __APPLE__
 	if (ngroups < 0)
-        fprintf(stderr, "id: failed to retrieve group list\n");
+        fprintf(stderr, "id: failed to retrieve group list: %s\n", strerror(errno));
         // warn("failed to retrieve group list");
 #endif
 
@@ -371,7 +371,7 @@ auditid(void)
 
     if (getaudit_addr(&auditinfo, sizeof(auditinfo)) < 0) {
 		// err(1, "getaudit");
-        fprintf(stderr, "id: getaudit\n");
+        fprintf(stderr, "id: getaudit: %s\n", strerror(errno));
         pthread_exit(NULL);
     }
 	printf("auid=%d\n", auditinfo.ai_auid);
@@ -389,7 +389,7 @@ fullname(struct passwd *pw)
 	if (!pw) {
         if ((pw = getpwuid(getuid())) == NULL) {
 			// err(1, "getpwuid");
-            fprintf(stderr, "id: getpwuid\n");
+            fprintf(stderr, "id: getpwuid: %s\n", strerror(errno));
             pthread_exit(NULL);
         }
 	}
@@ -458,7 +458,7 @@ maclabel(void)
 {
 #ifdef __APPLE__
 	// errx(1, "-M unsupported");
-    fprintf(stderr, "-M unsupported");
+    fprintf(stderr, "id: -M unsupported");
     pthread_exit(NULL);
 #else /* !__APPLE__ */
 	char *string;
@@ -513,7 +513,7 @@ pline(struct passwd *pw)
 	if (!pw) {
         if ((pw = getpwuid(getuid())) == NULL) {
 			// err(1, "getpwuid");
-            fprintf(stderr, "id: getpwuid\n");
+            fprintf(stderr, "id: getpwuid: %s\n", strerror(errno));
             pthread_exit(NULL);
         }
 	}

--- a/Dependencies/ios_system/shell_cmds/pwd/pwd.c
+++ b/Dependencies/ios_system/shell_cmds/pwd/pwd.c
@@ -50,6 +50,7 @@ __FBSDID("$FreeBSD: src/bin/pwd/pwd.c,v 1.25 2005/02/09 17:37:38 ru Exp $");
 #include <stdio.h>
 #include <stdlib.h>
 #include <unistd.h>
+#include <string.h>
 #include "ios_error.h"
 
 static char *getcwd_logical(void);
@@ -95,7 +96,7 @@ pwd_main(int argc, char *argv[])
 		printf("%s\n", p);
     else {
 		// err(1, ".");
-        fprintf(stderr, "pwd: .\n");
+        fprintf(stderr, "pwd: .: %s\n", strerror(errno));
         pthread_exit(NULL);
     }
 

--- a/Dependencies/ios_system/shell_cmds/uname/uname.c
+++ b/Dependencies/ios_system/shell_cmds/uname/uname.c
@@ -49,6 +49,7 @@ __RCSID("$NetBSD: uname.c,v 1.10 1998/11/09 13:24:05 kleink Exp $");
 
 #include <sys/sysctl.h>
 #include <sys/utsname.h>
+#include <errno.h>
 #include "ios_error.h"
 
 #ifdef __APPLE__
@@ -131,7 +132,7 @@ uname_main(argc, argv)
 
 	if (uname(&u) != 0) {
 		// err(EXIT_FAILURE, "uname");
-        fprintf(stderr, "uname\n");
+        fprintf(stderr, "uname: %s\n", strerror(errno));
         pthread_exit(NULL);
 		/* NOTREACHED */
 	}

--- a/Dependencies/ios_system/shell_cmds/w/w.c
+++ b/Dependencies/ios_system/shell_cmds/w/w.c
@@ -129,7 +129,7 @@ char	      **sel_users;	/* login array of particular users selected */
 /*
  * One of these per active utmp entry.
  */
-struct	utmp_entry {
+static struct	utmp_entry {
 	struct	utmp_entry *next;
 #if HAVE_UTMPX
 	struct	utmpx utmp;
@@ -295,7 +295,7 @@ w_main(int argc, char *argv[])
 #else
     if ((ut = fopen(_PATH_UTMP, "r")) == NULL) {
 		// err(1, "%s", _PATH_UTMP);
-        fprintf(stderr, "w: %s\n", _PATH_UTMP);
+        fprintf(stderr, "w: %s: %s\n", _PATH_UTMP, strerror(errno));
         pthread_exit(NULL);
     }
 #endif
@@ -409,7 +409,7 @@ w_main(int argc, char *argv[])
 #if HAVE_KVM
     if ((kp = kvm_getprocs(kd, KERN_PROC_ALL, 0, &nentries)) == NULL) {
 		// err(1, "%s", kvm_geterr(kd));
-        fprintf(stderr, "w: %s\n", kvm_geterr(kd));
+        fprintf(stderr, "w: %s: %s\n", kvm_geterr(kd), strerror(errno));
         pthread_exit(NULL);
     }
 #else
@@ -500,9 +500,11 @@ w_main(int argc, char *argv[])
 #else
 		w_getargv();
 #endif /* HAVE_KVM */
-		if (ep->args == NULL)
+        if (ep->args == NULL) {
+            fprintf(stderr, "w: %s\n", strerror(errno));
             pthread_exit(NULL);
 			// err(1, NULL);
+        }
 	}
 	/* sort by idle time */
 	if (sortidle && ehead != NULL) {
@@ -691,7 +693,7 @@ ttystat(char *line, int sz)
 	if (stat(ttybuf, &sb) == 0) {
 		return (&sb);
 	} else {
-        fprintf(stderr, "w: %s\n", ttybuf);
+        fprintf(stderr, "w: %s: %s\n", ttybuf, strerror(errno));
         // warn("%s", ttybuf);
 		return (NULL);
 	}

--- a/Dependencies/ios_system/text_cmds.patch
+++ b/Dependencies/ios_system/text_cmds.patch
@@ -1,6 +1,6 @@
 diff -Naur text_cmds-99/cat/cat.c text_cmds/cat/cat.c
 --- text_cmds-99/cat/cat.c	2005-09-20 23:36:44.000000000 +0200
-+++ text_cmds/cat/cat.c	2017-12-13 20:56:40.000000000 +0100
++++ text_cmds/cat/cat.c	2018-01-10 11:31:02.000000000 +0100
 @@ -55,7 +55,7 @@
  #endif
  
@@ -55,7 +55,7 @@ diff -Naur text_cmds-99/cat/cat.c text_cmds/cat/cat.c
  		}
  		if (fd < 0) {
 -			warn("%s", path);
-+            fprintf(stderr, "cat: %s\n", path);
++            fprintf(stderr, "cat: %s: %s\n", path, strerror(errno));
 +            // warn("%s", path);
  			rval = 1;
  		} else if (cooked) {
@@ -65,7 +65,7 @@ diff -Naur text_cmds-99/cat/cat.c text_cmds/cat/cat.c
  	}
  	if (ferror(fp)) {
 -		warn("%s", filename);
-+        fprintf(stderr, "cat: %s\n", filename);
++        fprintf(stderr, "cat: %s: %s\n", filename, strerror(errno));
 +        // warn("%s", filename);
  		rval = 1;
  		clearerr(fp);
@@ -74,7 +74,7 @@ diff -Naur text_cmds-99/cat/cat.c text_cmds/cat/cat.c
 -		err(1, "stdout");
 +    if (ferror(stdout)) {
 +		// err(1, "stdout");
-+        fprintf(stderr, "cat: stdout\n");
++        fprintf(stderr, "cat: stdout: %s\n", strerror(errno));
 +        pthread_exit(NULL);
 +    }
  }
@@ -99,7 +99,7 @@ diff -Naur text_cmds-99/cat/cat.c text_cmds/cat/cat.c
 +        bsize = 1024; // MAX(sbuf.st_blksize, 1024);
 +        if ((buf = malloc(bsize)) == NULL) {
 +            // err(1, "buffer");
-+            fprintf(stderr, "cat: buffer\n");
++            fprintf(stderr, "cat: buffer: %s\n", strerror(errno));
 +            pthread_exit(NULL);
 +        }
  	}
@@ -118,7 +118,7 @@ diff -Naur text_cmds-99/cat/cat.c text_cmds/cat/cat.c
 +        }
  	if (nr < 0) {
 -		warn("%s", filename);
-+        fprintf(stderr, "cat: %s\n", filename);
++        fprintf(stderr, "cat: %s: %s\n", filename, strerror(errno));
 +        // warn("%s", filename);
  		rval = 1;
  	}
@@ -132,20 +132,221 @@ diff -Naur text_cmds-99/cat/cat.c text_cmds/cat/cat.c
  		case O_RDONLY:
  			if (shutdown(fd, SHUT_WR) == -1)
 -				warn(NULL);
-+				fprintf(stderr, "\n");
++                fprintf(stderr, "cat: %s\n", strerror(errno));
 +                // warn(NULL);
  			break;
  		case O_WRONLY:
  			if (shutdown(fd, SHUT_RD) == -1)
 -				warn(NULL);
-+                fprintf(stderr, "\n");
++                fprintf(stderr, "cat: %s\n", strerror(errno));
 +				// warn(NULL);
  			break;
  		default:
  			break;
+diff -Naur text_cmds-99/ed/buf.c text_cmds/ed/buf.c
+--- text_cmds-99/ed/buf.c	2005-09-20 23:36:44.000000000 +0200
++++ text_cmds/ed/buf.c	2018-01-10 11:31:02.000000000 +0100
+@@ -33,6 +33,10 @@
+ #include <sys/stat.h>
+ 
+ #include "ed.h"
++// from ios_system:
++#include "ios_error.h"
++#include <pthread.h>
++#import <Foundation/Foundation.h>
+ 
+ 
+ FILE *sfp;				/* scratch file pointer */
+@@ -185,7 +189,7 @@
+ 
+ extern int newline_added;
+ 
+-char sfn[15] = "";				/* scratch file name */
++char sfn[PATH_MAX] = "";				/* scratch file name */
+ 
+ /* open_sbuf: open scratch file */
+ int
+@@ -196,7 +200,10 @@
+ 
+ 	isbinary = newline_added = 0;
+ 	u = umask(077);
+-	strcpy(sfn, "/tmp/ed.XXXXXX");
++    // getenv($HOME) + "/tmp/" or NSString * NSTemporaryDirectory(void);
++    // the latter, I guess.
++    sprintf(sfn, "%s/ed.XXXXXX", NSTemporaryDirectory().UTF8String);
++	// strcpy(sfn, "/tmp/ed.XXXXXX");
+ 	if ((fd = mkstemp(sfn)) == -1 ||
+ 	    (sfp = fdopen(fd, "w+")) == NULL) {
+ 		if (fd != -1)
+@@ -237,7 +244,8 @@
+ 		fclose(sfp);
+ 		unlink(sfn);
+ 	}
+-	exit(n);
++	// exit(n);
++    pthread_exit(NULL);
+ }
+ 
+ 
+diff -Naur text_cmds-99/ed/ed.h text_cmds/ed/ed.h
+--- text_cmds-99/ed/ed.h	2005-09-20 23:36:44.000000000 +0200
++++ text_cmds/ed/ed.h	2018-01-10 11:31:02.000000000 +0100
+@@ -275,7 +275,7 @@
+ extern long current_addr;
+ extern const char *errmsg;
+ extern long first_addr;
+-extern int lineno;
++extern int ed_lineno;
+ extern long second_addr;
+ extern long u_addr_last;
+ extern long u_current_addr;
+diff -Naur text_cmds-99/ed/io.c text_cmds/ed/io.c
+--- text_cmds-99/ed/io.c	2005-09-20 23:36:44.000000000 +0200
++++ text_cmds/ed/io.c	2018-01-10 11:31:02.000000000 +0100
+@@ -267,7 +267,7 @@
+ 			if (!(ibuf[i++] = c)) isbinary = 1;
+ 			if (c != '\n')
+ 				continue;
+-			lineno++;
++			ed_lineno++;
+ 			ibuf[i] = '\0';
+ 			ibufp = ibuf;
+ 			return i;
+diff -Naur text_cmds-99/ed/main.c text_cmds/ed/main.c
+--- text_cmds-99/ed/main.c	2006-04-21 01:51:01.000000000 +0200
++++ text_cmds/ed/main.c	2018-01-10 11:31:02.000000000 +0100
+@@ -59,13 +59,17 @@
+ #include <pwd.h>
+ #include <setjmp.h>
+ 
+-#ifdef __APPLE__
+-#include <get_compat.h>
+-#else
++// #ifdef __APPLE__
++// #include <get_compat.h>
++// #else
+ #define COMPAT_MODE(a,b) (1)
+-#endif /* __APPLE__ */
++// #endif /* __APPLE__ */
+ 
+ #include "ed.h"
++// from ios_system:
++#include "ios_error.h"
++#include <pthread.h>
++extern int ios_system(char* cmd);
+ 
+ 
+ #ifdef _POSIX_SOURCE
+@@ -100,18 +104,46 @@
+ char old_filename[PATH_MAX + 1] = "";	/* default filename */
+ long current_addr;		/* current address in editor buffer */
+ long addr_last;			/* last address in editor buffer */
+-int lineno;			/* script line number */
++int ed_lineno;			/* script line number */
+ const char *prompt;		/* command-line prompt */
+ const char *dps = "*";		/* default command-line prompt */
+ 
+-const char usage[] = "usage: %s [-] [-sx] [-p string] [file]\n";
++const char ed_usage[] = "usage: %s [-] [-sx] [-p string] [file]\n";
+ 
+ /* ed: line editor */
+ int
+-main(int argc, char *argv[])
++ed_main(int argc, char *argv[])
+ {
+ 	int c, n;
+ 	long status = 0;
++    // iOS: init all flags and variables:
++    /* global flags */
++    des = 0;            /* if set, use crypt(3) for i/o */
++    garrulous = 0;        /* if set, print all error messages */
++    isbinary = 0;            /* if set, buffer contains ASCII NULs */
++    isglobal = 0;            /* if set, doing a global command */
++    modified = 0;            /* if set, buffer modified since last write */
++    mutex = 0;            /* if set, signals set "sigflags" */
++    red = 0;            /* if set, restrict shell/directory access */
++    scripted = 0;        /* if set, suppress diagnostics */
++    sigflags = 0;        /* if set, signals received while mutex set */
++    sigactive = 0;        /* if set, signal handlers are enabled */
++    posixly_correct = 0;    /* if set, POSIX behavior as per */
++    /* http://www.opengroup.org/onlinepubs/009695399/utilities/ed.html */
++    
++    old_filename[0] = 0x0;    /* default filename */
++    current_addr = 0;        /* current address in editor buffer */
++    addr_last = 0;            /* last address in editor buffer */
++    ed_lineno = 0;            /* script line number */
++    prompt = 0;        /* command-line prompt */
++    shcmd = 0;            /* shell command buffer */
++    shcmdsz = 0;            /* shell command buffer size */
++    shcmdi = 0;            /* shell command buffer index */
++    ibuf = 0;            /* ed command-line buffer */
++    ibufsz = 0;            /* ed command-line buffer size */
++    ibufp = 0;            /* pointer to ed command-line buffer */
++
++    
+ #if __GNUC__
+ 	/* Avoid longjmp clobbering */
+ 	(void) &argc;
+@@ -141,8 +173,9 @@
+ 			break;
+ 
+ 		default:
+-			fprintf(stderr, usage, red ? "red" : "ed");
+-			exit(1);
++			fprintf(stderr, ed_usage, red ? "red" : "ed");
++            pthread_exit(NULL);
++			// exit(1);
+ 		}
+ 	argv += optind;
+ 	argc -= optind;
+@@ -210,7 +243,7 @@
+ 				if (!isatty(0)) {
+ 					fprintf(stderr, garrulous ?
+ 					    "script, line %d: %s\n" :
+-					    "", lineno, errmsg);
++					    "", ed_lineno, errmsg);
+ 					quit(2);
+ 				}
+ 				clearerr(stdin);
+@@ -243,7 +276,7 @@
+ 			if (!isatty(0)) {
+ 				fprintf(stderr, garrulous ?
+ 				    "script, line %d: %s\n" :
+-				    "", lineno, errmsg);
++				    "", ed_lineno, errmsg);
+ 				quit(2);
+ 			}
+ 			break;
+@@ -251,7 +284,7 @@
+ 			if (!isatty(0))
+ 				fprintf(stderr, garrulous ?
+ 				    "script, line %d: %s\n" : "",
+-				    lineno, errmsg);
++				    ed_lineno, errmsg);
+ 			else
+ 				fprintf(stderr, garrulous ? "%s\n" : "",
+ 				    errmsg);
+@@ -261,7 +294,7 @@
+ 			if (!isatty(0)) {
+ 				fprintf(stderr, garrulous ?
+ 				    "script, line %d: %s\n" : "",
+-				    lineno, errmsg);
++				    ed_lineno, errmsg);
+ 				quit(2);
+ 			}
+ 			break;
+@@ -888,7 +921,7 @@
+ 		GET_COMMAND_SUFFIX();
+ 		if (sflags) printf("%s\n", shcmd + 1);
+ 		fflush(stdout);
+-		system(shcmd + 1);
++		ios_system(shcmd + 1);
+ 		if (!scripted) printf("!\n");
+ 		break;
+ 	case '\n':
 diff -Naur text_cmds-99/grep/file.c text_cmds/grep/file.c
 --- text_cmds-99/grep/file.c	2015-08-18 22:29:43.000000000 +0200
-+++ text_cmds/grep/file.c	2017-12-12 23:58:21.000000000 +0100
++++ text_cmds/grep/file.c	2018-01-10 11:31:02.000000000 +0100
 @@ -38,7 +38,7 @@
  #include <sys/stat.h>
  #include <sys/types.h>
@@ -157,7 +358,7 @@ diff -Naur text_cmds-99/grep/file.c text_cmds/grep/file.c
  #ifndef WITHOUT_LZMA
 diff -Naur text_cmds-99/grep/grep.c text_cmds/grep/grep.c
 --- text_cmds-99/grep/grep.c	2015-08-18 22:29:43.000000000 +0200
-+++ text_cmds/grep/grep.c	2017-12-12 23:58:22.000000000 +0100
++++ text_cmds/grep/grep.c	2018-01-10 11:31:02.000000000 +0100
 @@ -36,7 +36,7 @@
  #include <sys/types.h>
  
@@ -210,7 +411,7 @@ diff -Naur text_cmds-99/grep/grep.c text_cmds/grep/grep.c
 -		err(2, "%s", fn);
 +    if ((f = fopen(fn, "r")) == NULL) {
 +		// err(2, "%s", fn);
-+        fprintf(stderr, "grep: %s\n", fn);
++        fprintf(stderr, "grep: %s: %s\n", fn, strerror(errno));
 +        pthread_exit(NULL);
 +    }
  	if ((fstat(fileno(f), &st) == -1) || (S_ISDIR(st.st_mode))) {
@@ -223,7 +424,7 @@ diff -Naur text_cmds-99/grep/grep.c text_cmds/grep/grep.c
 -		err(2, "%s", fn);
 +    if (ferror(f)) {
 +		// err(2, "%s", fn);
-+        fprintf(stderr, "grep: %s\n", fn);
++        fprintf(stderr, "grep: %s: %s\n", fn, strerror(errno));
 +        pthread_exit(NULL);
 +    }
  	fclose(f);
@@ -289,32 +490,38 @@ diff -Naur text_cmds-99/grep/grep.c text_cmds/grep/grep.c
  	if (pn[0] == 'b' && pn[1] == 'z') {
  		filebehave = FILE_BZIP;
  		pn += 2;
-@@ -441,7 +482,8 @@
+@@ -441,7 +482,9 @@
  				Aflag = 0;
  			else if (Aflag > LLONG_MAX / 10) {
  				errno = ERANGE;
 -				err(2, NULL);
++                fprintf(stderr, "grep: %s\n", strerror(errno));
 +                pthread_exit(NULL);
 +				// err(2, NULL);
  			}
  			Aflag = Bflag = (Aflag * 10) + (c - '0');
  			break;
-@@ -458,10 +500,12 @@
+@@ -457,11 +500,16 @@
+ 			errno = 0;
  			l = strtoull(optarg, &ep, 10);
  			if (((errno == ERANGE) && (l == ULLONG_MAX)) ||
- 			    ((errno == EINVAL) && (l == 0)))
+-			    ((errno == EINVAL) && (l == 0)))
 -				err(2, NULL);
++                ((errno == EINVAL) && (l == 0))) {
++                fprintf(stderr, "grep: %s\n", strerror(errno));
 +                pthread_exit(NULL);
 +                // err(2, NULL);
++            }
  			else if (ep[0] != '\0') {
  				errno = EINVAL;
 -				err(2, NULL);
++                fprintf(stderr, "grep: %s\n", strerror(errno));
 +                pthread_exit(NULL);
 +                // err(2, NULL);
  			}
  			if (c == 'A')
  				Aflag = l;
-@@ -484,8 +528,11 @@
+@@ -484,8 +532,11 @@
  				devbehave = DEV_SKIP;
  			else if (strcasecmp(optarg, "read") == 0)
  				devbehave = DEV_READ;
@@ -328,7 +535,7 @@ diff -Naur text_cmds-99/grep/grep.c text_cmds/grep/grep.c
  			break;
  		case 'd':
  			if (strcasecmp("recurse", optarg) == 0) {
-@@ -495,8 +542,11 @@
+@@ -495,8 +546,11 @@
  				dirbehave = DIR_SKIP;
  			else if (strcasecmp("read", optarg) == 0)
  				dirbehave = DIR_READ;
@@ -342,27 +549,32 @@ diff -Naur text_cmds-99/grep/grep.c text_cmds/grep/grep.c
  			break;
  		case 'E':
  			grepbehave = GREP_EXTENDED;
-@@ -533,7 +583,9 @@
+@@ -533,7 +587,9 @@
  		case 'J':
  #ifdef WITHOUT_BZIP2
  			errno = EOPNOTSUPP;
 -			err(2, "bzip2 support was disabled at compile-time");
 +			// err(2, "bzip2 support was disabled at compile-time");
-+            fprintf(stderr, "grep: bzip2 support was disabled at compile-time\n");
++                fprintf(stderr, "grep: bzip2 support was disabled at compile-time: %s\n", strerror(errno));
 +            pthread_exit(NULL);
  #endif
  			filebehave = FILE_BZIP;
  			break;
-@@ -551,16 +603,20 @@
+@@ -550,17 +606,24 @@
+ 			errno = 0;
  			mcount = strtoll(optarg, &ep, 10);
  			if (((errno == ERANGE) && (mcount == LLONG_MAX)) ||
- 			    ((errno == EINVAL) && (mcount == 0)))
+-			    ((errno == EINVAL) && (mcount == 0)))
 -				err(2, NULL);
++                ((errno == EINVAL) && (mcount == 0))) {
++                fprintf(stderr, "grep: %s\n", strerror(errno));
 +                pthread_exit(NULL);
 +                // err(2, NULL);
++            }
  			else if (ep[0] != '\0') {
  				errno = EINVAL;
 -				err(2, NULL);
++                fprintf(stderr, "grep: %s\n", strerror(errno));
 +                pthread_exit(NULL);
 +                // err(2, NULL);
  			}
@@ -372,12 +584,12 @@ diff -Naur text_cmds-99/grep/grep.c text_cmds/grep/grep.c
  			errno = EOPNOTSUPP;
 -			err(2, "lzma support was disabled at compile-time");
 +			// err(2, "lzma support was disabled at compile-time");
-+            fprintf(stderr, "grep: lzma support was disabled at compile-time\n");
++                fprintf(stderr, "grep: lzma support was disabled at compile-time: %s\n", strerror(errno));
 +            pthread_exit(NULL);
  #endif
  			filebehave = FILE_LZMA;
  			break;
-@@ -602,7 +658,7 @@
+@@ -602,7 +665,7 @@
  #endif
  			break;
  		case 'V':
@@ -386,18 +598,18 @@ diff -Naur text_cmds-99/grep/grep.c text_cmds/grep/grep.c
  			exit(0);
  		case 'v':
  			vflag = true;
-@@ -618,7 +674,9 @@
+@@ -618,7 +681,9 @@
  		case 'X':
  #ifdef WITHOUT_LZMA
  			errno = EOPNOTSUPP;
 -			err(2, "xz support was disabled at compile-time");
 +			// err(2, "xz support was disabled at compile-time");
-+            fprintf(stderr, "grep: xz support was disabled at compile-time\n");
++                fprintf(stderr, "grep: xz support was disabled at compile-time: %s\n", strerror(errno));
 +            pthread_exit(NULL);
  #endif
  			filebehave = FILE_XZ;
  			break;
-@@ -632,8 +690,11 @@
+@@ -632,8 +697,11 @@
  				binbehave = BINFILE_SKIP;
  			else if (strcasecmp("text", optarg) == 0)
  				binbehave = BINFILE_TEXT;
@@ -411,7 +623,7 @@ diff -Naur text_cmds-99/grep/grep.c text_cmds/grep/grep.c
  			break;
  		case COLOR_OPT:
  			color = NULL;
-@@ -652,8 +713,11 @@
+@@ -652,8 +720,11 @@
  				color = init_color("01;31");
  			} else if (strcasecmp("never", optarg) != 0 &&
  			    strcasecmp("none", optarg) != 0 &&
@@ -425,7 +637,7 @@ diff -Naur text_cmds-99/grep/grep.c text_cmds/grep/grep.c
  			cflags &= ~REG_NOSUB;
  			break;
  		case LABEL_OPT:
-@@ -748,7 +812,9 @@
+@@ -748,7 +819,9 @@
  			if (c != 0) {
  				regerror(c, &r_pattern[i], re_error,
  				    RE_ERROR_BUF);
@@ -438,7 +650,7 @@ diff -Naur text_cmds-99/grep/grep.c text_cmds/grep/grep.c
  		}
 diff -Naur text_cmds-99/grep/util.c text_cmds/grep/util.c
 --- text_cmds-99/grep/util.c	2015-09-10 22:25:31.000000000 +0200
-+++ text_cmds/grep/util.c	2017-12-12 23:58:22.000000000 +0100
++++ text_cmds/grep/util.c	2018-01-10 11:31:02.000000000 +0100
 @@ -39,7 +39,7 @@
  #endif
  
@@ -464,7 +676,7 @@ diff -Naur text_cmds-99/grep/util.c text_cmds/grep/util.c
 -		err(2, "fts_open");
 +    if (!(fts = fts_open(argv, fts_flags, NULL))) {
 +		// err(2, "fts_open");
-+        fprintf(stderr, "grep: fts_open\n");
++        fprintf(stderr, "grep: fts_open: %s\n", strerror(errno));
 +        pthread_exit(NULL);
 +    }
  	while ((p = fts_read(fts)) != NULL) {
@@ -505,7 +717,7 @@ diff -Naur text_cmds-99/grep/util.c text_cmds/grep/util.c
  		file_err = true;
  		if (!sflag)
 -			warn("%s", fn);
-+            fprintf(stderr, "grep: %s\n", fn);
++            fprintf(stderr, "grep: %s: %s\n", fn, strerror(errno));
 +            // warn("%s", fn);
  		return (0);
  	}
@@ -518,7 +730,7 @@ diff -Naur text_cmds-99/grep/util.c text_cmds/grep/util.c
 -		err(2, "malloc");
 +    if ((ptr = malloc(size)) == NULL) {
 +		// err(2, "malloc");
-+        fprintf(stderr, "grep: malloc\n");
++        fprintf(stderr, "grep: malloc: %s\n", strerror(errno));
 +        pthread_exit(NULL);
 +    }
  	return (ptr);
@@ -532,7 +744,7 @@ diff -Naur text_cmds-99/grep/util.c text_cmds/grep/util.c
 -		err(2, "calloc");
 +    if ((ptr = calloc(nmemb, size)) == NULL) {
 +        // err(2, "calloc");
-+        fprintf(stderr, "grep: malloc\n");
++        fprintf(stderr, "grep: calloc: %s\n", strerror(errno));
 +    pthread_exit(NULL);
 +}
  	return (ptr);
@@ -546,7 +758,7 @@ diff -Naur text_cmds-99/grep/util.c text_cmds/grep/util.c
 -		err(2, "realloc");
 +    if ((ptr = realloc(ptr, size)) == NULL) {
 +        // err(2, "realloc");
-+        fprintf(stderr, "grep: realloc\n");
++        fprintf(stderr, "grep: realloc: %s\n", strerror(errno));
 +        pthread_exit(NULL);
 +    }
  	return (ptr);
@@ -560,15 +772,1034 @@ diff -Naur text_cmds-99/grep/util.c text_cmds/grep/util.c
 -		err(2, "strdup");
 +    if ((ret = strdup(str)) == NULL) {
 +        // err(2, "strdup");
-+        fprintf(stderr, "grep: strdup\n");
++        fprintf(stderr, "grep: strdup: %s\n", strerror(errno));
 +        pthread_exit(NULL);
 +    }
  	return (ret);
  }
  
+diff -Naur text_cmds-99/sed/compile.c text_cmds/sed/compile.c
+--- text_cmds-99/sed/compile.c	2006-12-05 23:29:30.000000000 +0100
++++ text_cmds/sed/compile.c	2018-01-10 11:31:02.000000000 +0100
+@@ -54,12 +54,13 @@
+ 
+ #include "defs.h"
+ #include "extern.h"
++#include "ios_error.h"
+ 
+-#ifdef __APPLE__
+-#include <get_compat.h>
+-#else
++// #ifdef __APPLE__
++// #include <get_compat.h>
++// #else
+ #define COMPAT_MODE(a,b) (1)
+-#endif /* __APPLE__ */
++// #endif /* __APPLE__ */
+ 
+ #define LHSZ	128
+ #define	LHMASK	(LHSZ - 1)
+@@ -145,9 +146,9 @@
+ 		appends = NULL;
+ 	else if ((appends = malloc(sizeof(struct s_appends) * appendnum)) ==
+ 	    NULL)
+-		err(1, "malloc");
++    { fprintf(stderr, "sed: malloc: %s\n", strerror(errno)); pthread_exit(NULL); } // err(1, "malloc");
+ 	if ((match = malloc((maxnsub + 1) * sizeof(regmatch_t))) == NULL)
+-		err(1, "malloc");
++    { fprintf(stderr, "sed: malloc: %s\n", strerror(errno)); pthread_exit(NULL); } // err(1, "malloc");
+ }
+ 
+ #define EATSPACE() do {							\
+@@ -169,8 +170,11 @@
+ 	for (;;) {
+ 		if ((p = cu_fgets(lbuf, sizeof(lbuf), NULL)) == NULL) {
+ 			if (stack != 0)
+-				errx(1, "%lu: %s: unexpected EOF (pending }'s)",
++            { fprintf(stderr, "sed: %lu: %s: unexpected EOF (pending }'s)\n",
++				// errx(1, "%lu: %s: unexpected EOF (pending }'s)",
+ 							linenum, fname);
++                pthread_exit(NULL);
++            }
+ 			return (link);
+ 		}
+ 
+@@ -184,7 +188,7 @@
+ 			}
+ 		}
+ 		if ((*link = cmd = malloc(sizeof(struct s_command))) == NULL)
+-			err(1, "malloc");
++        { fprintf(stderr, "sed: malloc: %s\n", strerror(errno)); pthread_exit(NULL); } // err(1, "malloc");
+ 		link = &cmd->next;
+ 		cmd->nonsel = cmd->inrange = 0;
+ 		/* First parse the addresses */
+@@ -195,7 +199,7 @@
+ 		if (addrchar(*p)) {
+ 			naddr++;
+ 			if ((cmd->a1 = malloc(sizeof(struct s_addr))) == NULL)
+-				err(1, "malloc");
++            { fprintf(stderr, "sed: malloc: %s\n", strerror(errno)); pthread_exit(NULL); } // err(1, "malloc");
+ 			p = compile_addr(p, cmd->a1);
+ 			EATSPACE();				/* EXTENSION */
+ 			if (*p == ',') {
+@@ -204,7 +208,7 @@
+ 				naddr++;
+ 				if ((cmd->a2 = malloc(sizeof(struct s_addr)))
+ 				    == NULL)
+-					err(1, "malloc");
++                { fprintf(stderr, "sed: malloc: %s\n", strerror(errno)); pthread_exit(NULL); } // err(1, "malloc");
+ 				p = compile_addr(p, cmd->a2);
+ 				EATSPACE();
+ 			} else
+@@ -214,17 +218,24 @@
+ 
+ nonsel:		/* Now parse the command */
+ 		if (!*p)
+-			errx(1, "%lu: %s: command expected", linenum, fname);
++        { fprintf(stderr, "sed: %lu: %s: command expected\n", linenum, fname); pthread_exit(NULL); }
++            // errx(1, "%lu: %s: command expected", linenum, fname);
+ 		cmd->code = *p;
+ 		for (fp = cmd_fmts; fp->code; fp++)
+ 			if (fp->code == *p)
+ 				break;
+ 		if (!fp->code)
+-			errx(1, "%lu: %s: invalid command code %c", linenum, fname, *p);
++        { fprintf(stderr, "sed: %lu: %s: invalid command code %c\n", linenum, fname, *p); pthread_exit(NULL); }
++			// errx(1, "%lu: %s: invalid command code %c", linenum, fname, *p);
+ 		if (naddr > fp->naddr)
+-			errx(1,
+-				"%lu: %s: command %c expects up to %d address(es), found %d",
+-				linenum, fname, *p, fp->naddr, naddr);
++        { fprintf(stderr,
++                  "sed: %lu: %s: command %c expects up to %d address(es), found %d\n",
++                 linenum, fname, *p, fp->naddr, naddr);
++            pthread_exit(NULL);
++        }
++			// errx(1,
++			//	"%lu: %s: command %c expects up to %d address(es), found %d",
++			//	linenum, fname, *p, fp->naddr, naddr);
+ 		switch (fp->args) {
+ 		case NONSEL:			/* ! */
+ 			p++;
+@@ -247,7 +258,8 @@
+ 			 */
+ 			cmd->nonsel = 1;
+ 			if (stack == 0)
+-				errx(1, "%lu: %s: unexpected }", linenum, fname);
++            { fprintf(stderr, "sed: %lu: %s: unexpected }\n", linenum, fname); pthread_exit(NULL); }
++                // errx(1, "%lu: %s: unexpected }", linenum, fname);
+ 			cmd2 = stack;
+ 			stack = cmd2->next;
+ 			cmd2->next = cmd;
+@@ -261,21 +273,31 @@
+ 				goto semicolon;
+ 			}
+ 			if (*p)
+-				errx(1, "%lu: %s: extra characters at the end of %c command",
+-						linenum, fname, cmd->code);
++            { fprintf(stderr, "sed: %lu: %s: extra characters at the end of %c command\n", linenum, fname, cmd->code); pthread_exit(NULL); }
++				// errx(1, "%lu: %s: extra characters at the end of %c command",
++						// linenum, fname, cmd->code);
+ 			break;
+ 		case TEXT:			/* a c i */
+ 			p++;
+ 			EATSPACE();
+ 			if (*p != '\\')
+-				errx(1,
+-"%lu: %s: command %c expects \\ followed by text", linenum, fname, cmd->code);
++            { fprintf(stderr,
++                      "sed: %lu: %s: command %c expects \\ followed by text\n", linenum, fname, cmd->code);
++                pthread_exit(NULL);
++            }
++				// errx(1,
++// "%lu: %s: command %c expects \\ followed by text", linenum, fname, cmd->code);
+ 			p++;
+ 			EATSPACE();
+ 			if (*p)
+-				errx(1,
+-				"%lu: %s: extra characters after \\ at the end of %c command",
+-				linenum, fname, cmd->code);
++            { fprintf(stderr,
++                      "sed: %lu: %s: extra characters after \\ at the end of %c command\n",
++                     linenum, fname, cmd->code);
++                pthread_exit(NULL);
++            }
++				// errx(1,
++				// "%lu: %s: extra characters after \\ at the end of %c command",
++				//linenum, fname, cmd->code);
+ 			cmd->t = compile_text();
+ 			break;
+ 		case COMMENT:			/* \0 # */
+@@ -284,20 +306,26 @@
+ 			p++;
+ 			EATSPACE();
+ 			if (*p == '\0')
+-				errx(1, "%lu: %s: filename expected", linenum, fname);
++            { fprintf(stderr, "sed: %lu: %s: filename expected\n", linenum, fname);
++                pthread_exit(NULL);
++            }
++             //   errx(1, "%lu: %s: filename expected", linenum, fname);
+ 			cmd->t = duptoeol(p, "w command");
+ 			if (aflag)
+ 				cmd->u.fd = -1;
+ 			else if ((cmd->u.fd = open(p,
+ 			    O_WRONLY|O_APPEND|O_CREAT|O_TRUNC,
+ 			    DEFFILEMODE)) == -1)
+-				err(1, "%s", p);
++            { fprintf(stderr, "sed: %s: %s\n", p, strerror(errno)); pthread_exit(NULL); }  // err(1, "%s", p);
+ 			break;
+ 		case RFILE:			/* r */
+ 			p++;
+ 			EATSPACE();
+ 			if (*p == '\0')
+-				errx(1, "%lu: %s: filename expected", linenum, fname);
++            { fprintf(stderr, "sed: %lu: %s: filename expected\n", linenum, fname);
++                pthread_exit(NULL);
++            }
++				// errx(1, "%lu: %s: filename expected", linenum, fname);
+ 			else
+ 				cmd->t = duptoeol(p, "read command");
+ 			break;
+@@ -314,21 +342,30 @@
+ 			EATSPACE();
+ 			cmd->t = duptoeol(p, "label");
+ 			if (strlen(p) == 0)
+-				errx(1, "%lu: %s: empty label", linenum, fname);
++            { fprintf(stderr, "sed: %lu: %s: empty label\n", linenum, fname);
++                pthread_exit(NULL);
++            }
++			//	errx(1, "%lu: %s: empty label", linenum, fname);
+ 			enterlabel(cmd);
+ 			break;
+ 		case SUBST:			/* s */
+ 			p++;
+ 			if (*p == '\0' || *p == '\\')
+-				errx(1,
+-"%lu: %s: substitute pattern can not be delimited by newline or backslash",
+-					linenum, fname);
++            { fprintf(stderr, "sed: %lu: %s: substitute pattern can not be delimited by newline or backslash\n", linenum, fname);
++                pthread_exit(NULL);
++            }
++				// errx(1,
++//"%lu: %s: substitute pattern can not be delimited by newline or backslash",
++	//				linenum, fname);
+ 			if ((cmd->u.s = malloc(sizeof(struct s_subst))) == NULL)
+-				err(1, "malloc");
++            { fprintf(stderr, "sed: malloc: %s\n", strerror(errno)); pthread_exit(NULL); } // err(1, "malloc");
+ 			p = compile_re(p, &cmd->u.s->re);
+ 			if (p == NULL)
+-				errx(1,
+-				"%lu: %s: unterminated substitute pattern", linenum, fname);
++            { fprintf(stderr, "sed: %lu: %s: unterminated substitute pattern\n", linenum, fname);
++                pthread_exit(NULL);
++            }
++				//errx(1,
++				// "%lu: %s: unterminated substitute pattern", linenum, fname);
+ 			--p;
+ 			p = compile_subst(p, cmd->u.s);
+ 			p = compile_flags(p, cmd->u.s);
+@@ -349,8 +386,12 @@
+ 				goto semicolon;
+ 			}
+ 			if (*p)
+-				errx(1,
+-"%lu: %s: extra text at the end of a transform command", linenum, fname);
++            { fprintf(stderr,
++                      "sed: %lu: %s: extra text at the end of a transform command\n", linenum, fname);
++                pthread_exit(NULL);
++            }
++				//errx(1,
++//"%lu: %s: extra text at the end of a transform command", linenum, fname);
+ 			break;
+ 		}
+ 	}
+@@ -374,15 +415,24 @@
+ 	if (c == '\0')
+ 		return (NULL);
+ 	else if (c == '\\')
+-		errx(1, "%lu: %s: \\ can not be used as a string delimiter",
++    { fprintf(stderr, "sed: %lu: %s: \\ can not be used as a string delimiter\n",
++             //errx(1, "%lu: %s: \\ can not be used as a string delimiter",
+ 				linenum, fname);
++        pthread_exit(NULL);
++    }
+ 	else if (c == '\n')
+-		errx(1, "%lu: %s: newline can not be used as a string delimiter",
++    { fprintf(stderr, "sed: %lu: %s: newline can not be used as a string delimiter\n",
++              // errx(1, "%lu: %s: newline can not be used as a string delimiter",
+ 				linenum, fname);
++        pthread_exit(NULL);
++    }
+ 	while (*p) {
+ 		if (*p == '[' && c != *p) {
+ 			if ((d = compile_ccl(&p, d)) == NULL)
+-				errx(1, "%lu: %s: unbalanced brackets ([])", linenum, fname);
++            { fprintf(stderr, "sed: %lu: %s: unbalanced brackets ([])", linenum, fname);
++				//errx(1, "%lu: %s: unbalanced brackets ([])", linenum, fname);
++                pthread_exit(NULL);
++            }
+ 			continue;
+ 		} else if (*p == '\\' && p[1] == '[') {
+ 			*d++ = *p++;
+@@ -451,10 +501,13 @@
+ 		return (p);
+ 	}
+ 	if ((*repp = malloc(sizeof(regex_t))) == NULL)
+-		err(1, "malloc");
++    { fprintf(stderr, "sed: malloc: %s\n", strerror(errno)); pthread_exit(NULL); } // err(1, "malloc");
+ 	if (p && (eval = regcomp(*repp, re, rflags)) != 0)
+-		errx(1, "%lu: %s: RE error: %s",
++    { fprintf(stderr, "sed: %lu: %s: RE error: %s\n",
++		// errx(1, "%lu: %s: RE error: %s",
+ 				linenum, fname, strregerror(eval, *repp));
++        pthread_exit(NULL);
++    }
+ 	if (maxnsub < (*repp)->re_nsub)
+ 		maxnsub = (*repp)->re_nsub;
+ 	return (p);
+@@ -482,7 +535,7 @@
+ 	s->linenum = linenum;
+ 	asize = 2 * _POSIX2_LINE_MAX + 1;
+ 	if ((text = malloc(asize)) == NULL)
+-		err(1, "malloc");
++    { fprintf(stderr, "sed: malloc: %s\n", strerror(errno)); pthread_exit(NULL); } // err(1, "malloc");
+ 	size = 0;
+ 	do {
+ 		op = sp = text + size;
+@@ -514,8 +567,11 @@
+ 					ref = *p - '0';
+ 					if (s->re != NULL &&
+ 					    ref > s->re->re_nsub)
+-						errx(1, "%lu: %s: \\%c not defined in the RE",
++                    { fprintf(stderr, "sed: %lu: %s: \\%c not defined in the RE\n",
++						// errx(1, "%lu: %s: \\%c not defined in the RE",
+ 								linenum, fname, *p);
++                        pthread_exit(NULL);
++                    }
+ 					if (s->maxbref < ref)
+ 						s->maxbref = ref;
+ 				} else if (*p == '&' || *p == '\\')
+@@ -528,11 +584,13 @@
+ 				*sp++ = '\0';
+ 				size += sp - op;
+ 				if ((s->new = realloc(text, size)) == NULL)
+-					err(1, "realloc");
++                { fprintf(stderr, "sed: realloc: %s\n", strerror(errno)); pthread_exit(NULL); } // err(1, "malloc");
+ 				return (p);
+ 			} else if (*p == '\n') {
+-				errx(1,
+-"%lu: %s: unescaped newline inside substitute pattern", linenum, fname);
++				fprintf(stderr,
++                    // errx(1,
++                        "sed: %lu: %s: unescaped newline inside substitute pattern\n", linenum, fname);
++                pthread_exit(NULL);
+ 				/* NOTREACHED */
+ 			}
+ 			*sp++ = *p;
+@@ -541,11 +599,13 @@
+ 		if (asize - size < _POSIX2_LINE_MAX + 1) {
+ 			asize *= 2;
+ 			if ((text = realloc(text, asize)) == NULL)
+-				err(1, "realloc");
++            { fprintf(stderr, "sed: realloc: %s\n", strerror(errno)); pthread_exit(NULL); } // err(1, "malloc");
+ 		}
+ 	} while (cu_fgets(p = lbuf, sizeof(lbuf), &more));
+-	errx(1, "%lu: %s: unterminated substitute in regular expression",
++    fprintf(stderr, "sed: %lu: %s: unterminated substitute in regular expression\n",
++         // errx(1, "%lu: %s: unterminated substitute in regular expression",
+ 			linenum, fname);
++    pthread_exit(NULL);
+ 	/* NOTREACHED */
+ }
+ 
+@@ -568,8 +628,11 @@
+ 		switch (*p) {
+ 		case 'g':
+ 			if (gn)
+-				errx(1,
+-"%lu: %s: more than one number or 'g' in substitute flags", linenum, fname);
++            { fprintf(stderr,
++                     //errx(1,
++                      "sed: %lu: %s: more than one number or 'g' in substitute flags\n", linenum, fname);
++                pthread_exit(NULL);
++            }
+ 			gn = 1;
+ 			s->n = 0;
+ 			break;
+@@ -584,14 +647,20 @@
+ 		case '4': case '5': case '6':
+ 		case '7': case '8': case '9':
+ 			if (gn)
+-				errx(1,
+-"%lu: %s: more than one number or 'g' in substitute flags", linenum, fname);
++            { fprintf(stderr,
++				// errx(1,
++                      "sed: %lu: %s: more than one number or 'g' in substitute flags\n", linenum, fname);
++                pthread_exit(NULL);
++            }
+ 			gn = 1;
+ 			errno = 0;
+ 			nval = strtol(p, &p, 10);
+ 			if (errno == ERANGE || nval > INT_MAX)
+-				errx(1,
+-"%lu: %s: overflow in the 'N' substitute flag", linenum, fname);
++            { fprintf(stderr,
++				//errx(1,
++                      "sed: %lu: %s: overflow in the 'N' substitute flag\n", linenum, fname);
++                pthread_exit(NULL);
++            }
+ 			s->n = nval;
+ 			p--;
+ 			break;
+@@ -599,7 +668,8 @@
+ 			p++;
+ #ifdef HISTORIC_PRACTICE
+ 			if (*p != ' ') {
+-				warnx("%lu: %s: space missing before w wfile", linenum, fname);
++                fprintf(stder, "sed: %lu: %s: space missing before w wfile\n", linenum, fname);
++				// warnx("%lu: %s: space missing before w wfile", linenum, fname);
+ 				return (p);
+ 			}
+ #endif
+@@ -612,16 +682,21 @@
+ 			}
+ 			*q = '\0';
+ 			if (q == wfile)
+-				errx(1, "%lu: %s: no wfile specified", linenum, fname);
++            { fprintf(stderr, "sed: %lu: %s: no wfile specified\n", linenum, fname);
++                pthread_exit(NULL);
++            }
++                // errx(1, "%lu: %s: no wfile specified", linenum, fname);
+ 			s->wfile = strdup(wfile);
+ 			if (!aflag && (s->wfd = open(wfile,
+ 			    O_WRONLY|O_APPEND|O_CREAT|O_TRUNC,
+ 			    DEFFILEMODE)) == -1)
+-				err(1, "%s", wfile);
++            { fprintf(stderr, "sed: %s: %s\n", wfile, strerror(errno)); pthread_exit(NULL); } // err(1, "%s", wfile);
+ 			return (p);
+ 		default:
+-			errx(1, "%lu: %s: bad flag in substitute command: '%c'",
++                fprintf(stderr, "sed: %lu: %s: bad flag in substitute command: '%c'\n",
++			// errx(1, "%lu: %s: bad flag in substitute command: '%c'",
+ 					linenum, fname, *p);
++                pthread_exit(NULL);
+ 			break;
+ 		}
+ 		p++;
+@@ -643,34 +718,46 @@
+ 	mbstate_t mbs1, mbs2;
+ 
+ 	if ((*py = y = malloc(sizeof(*y))) == NULL)
+-		err(1, NULL);
++    { fprintf(stderr, "sed: %s\n", strerror(errno)); pthread_exit(NULL); } // err(1, "malloc");
+ 	y->multis = NULL;
+ 	y->nmultis = 0;
+ 
+ 	if (*p == '\0' || *p == '\\')
+-		errx(1,
+-	"%lu: %s: transform pattern can not be delimited by newline or backslash",
++    { fprintf(stderr,
++             // errx(1,
++              "sed: %lu: %s: transform pattern can not be delimited by newline or backslash\n",
+ 			linenum, fname);
++        pthread_exit(NULL);
++    }
+ 	p = compile_delimited(p, old, 1);
+ 	if (p == NULL)
+-		errx(1, "%lu: %s: unterminated transform source string",
++    { fprintf(stderr, "sed: %lu: %s: unterminated transform source string\n",
++		// errx(1, "%lu: %s: unterminated transform source string",
+ 				linenum, fname);
++        pthread_exit(NULL);
++    }
+ 	p = compile_delimited(p - 1, new, 1);
+ 	if (p == NULL)
+-		errx(1, "%lu: %s: unterminated transform target string",
++    { fprintf(stderr, "sed: %lu: %s: unterminated transform target string\n",
++		// errx(1, "%lu: %s: unterminated transform target string",
+ 				linenum, fname);
++        pthread_exit(NULL);
++    }
+ 	EATSPACE();
+ 	op = old;
+ 	oldlen = mbsrtowcs(NULL, &op, 0, NULL);
+ 	if (oldlen == (size_t)-1)
+-		err(1, NULL);
++    { fprintf(stderr, "sed: %s\n", strerror(errno)); pthread_exit(NULL); } // err(1, "malloc");
+ 	np = new;
+ 	newlen = mbsrtowcs(NULL, &np, 0, NULL);
+ 	if (newlen == (size_t)-1)
+-		err(1, NULL);
++    { fprintf(stderr, "sed: %s\n", strerror(errno)); pthread_exit(NULL); } // err(1, "malloc");
+ 	if (newlen != oldlen)
+-		errx(1, "%lu: %s: transform strings are not the same length",
++    { fprintf(stderr, "sed: %lu: %s: transform strings are not the same length\n",
++		// errx(1, "%lu: %s: transform strings are not the same length",
+ 				linenum, fname);
++        pthread_exit(NULL);
++    }
+ 	if (MB_CUR_MAX == 1) {
+ 		/*
+ 		 * The single-byte encoding case is easy: generate a
+@@ -706,7 +793,7 @@
+ 				y->multis = realloc(y->multis,
+ 				    (y->nmultis + 1) * sizeof(*y->multis));
+ 				if (y->multis == NULL)
+-					err(1, NULL);
++                { fprintf(stderr, "sed: %s\n", strerror(errno)); pthread_exit(NULL); } // err(1, "malloc");
+ 				i = y->nmultis++;
+ 				y->multis[i].fromlen = oclen;
+ 				memcpy(y->multis[i].from, op, oclen);
+@@ -732,7 +819,7 @@
+ 
+ 	asize = 2 * _POSIX2_LINE_MAX + 1;
+ 	if ((text = malloc(asize)) == NULL)
+-		err(1, "malloc");
++    { fprintf(stderr, "sed: malloc: %s\n", strerror(errno)); pthread_exit(NULL); } // err(1, "malloc");
+ 	size = 0;
+ 	while (cu_fgets(lbuf, sizeof(lbuf), NULL)) {
+ 		op = s = text + size;
+@@ -751,12 +838,12 @@
+ 		if (asize - size < _POSIX2_LINE_MAX + 1) {
+ 			asize *= 2;
+ 			if ((text = realloc(text, asize)) == NULL)
+-				err(1, "realloc");
++            { fprintf(stderr, "sed: realloc: %s\n", strerror(errno)); pthread_exit(NULL); } // err(1, "malloc");
+ 		}
+ 	}
+ 	text[size] = '\0';
+ 	if ((p = realloc(text, size + 1)) == NULL)
+-		err(1, "realloc");
++    { fprintf(stderr, "sed: realloc: %s\n", strerror(errno)); pthread_exit(NULL); } // err(1, "malloc");
+ 	return (p);
+ }
+ 
+@@ -776,7 +863,10 @@
+ 	case '/':				/* Context address */
+ 		p = compile_re(p, &a->u.r);
+ 		if (p == NULL)
+-			errx(1, "%lu: %s: unterminated regular expression", linenum, fname);
++        { fprintf(stderr, "sed: %lu: %s: unterminated regular expression\n", linenum, fname);
++            pthread_exit(NULL);
++         //   errx(1, "%lu: %s: unterminated regular expression", linenum, fname);
++        }
+ 		a->type = AT_RE;
+ 		return (p);
+ 
+@@ -790,7 +880,9 @@
+ 		a->u.l = strtol(p, &end, 10);
+ 		return (end);
+ 	default:
+-		errx(1, "%lu: %s: expected context address", linenum, fname);
++            fprintf(stderr, "sed: %lu: %s: expected context address\n", linenum, fname);
++            pthread_exit(NULL);
++		// errx(1, "%lu: %s: expected context address", linenum, fname);
+ 		return (NULL);
+ 	}
+ }
+@@ -811,10 +903,11 @@
+ 		ws = isspace((unsigned char)*s);
+ 	*s = '\0';
+ 	if (ws)
+-		warnx("%lu: %s: whitespace after %s", linenum, fname, ctype);
++        fprintf(stderr, "sed: %lu: %s: whitespace after %s\n", linenum, fname, ctype);
++		// warnx("%lu: %s: whitespace after %s", linenum, fname, ctype);
+ 	len = s - start + 1;
+ 	if ((p = malloc(len)) == NULL)
+-		err(1, "malloc");
++    { fprintf(stderr, "sed: malloc: %s\n", strerror(errno)); pthread_exit(NULL); } // err(1, "malloc");
+ 	return (memmove(p, start, len));
+ }
+ 
+@@ -843,7 +936,10 @@
+ 				break;
+ 			}
+ 			if ((cp->u.c = findlabel(cp->t)) == NULL)
+-				errx(1, "%lu: %s: undefined label '%s'", linenum, fname, cp->t);
++            { fprintf(stderr, "sed: %lu: %s: undefined label '%s'\n", linenum, fname, cp->t);
++                pthread_exit(NULL);
++                // errx(1, "%lu: %s: undefined label '%s'", linenum, fname, cp->t);
++            }
+ 			free(cp->t);
+ 			break;
+ 		case '{':
+@@ -868,9 +964,12 @@
+ 	lhp = &labels[h & LHMASK];
+ 	for (lh = *lhp; lh != NULL; lh = lh->lh_next)
+ 		if (lh->lh_hash == h && strcmp(cp->t, lh->lh_cmd->t) == 0)
+-			errx(1, "%lu: %s: duplicate label '%s'", linenum, fname, cp->t);
++        { fprintf(stderr, "sed: %lu: %s: duplicate label '%s'\n", linenum, fname, cp->t);
++            pthread_exit(NULL);
++    // errx(1, "%lu: %s: duplicate label '%s'", linenum, fname, cp->t);
++        }
+ 	if ((lh = malloc(sizeof *lh)) == NULL)
+-		err(1, "malloc");
++    { fprintf(stderr, "sed: malloc: %s\n", strerror(errno)); pthread_exit(NULL); } // err(1, "malloc");
+ 	lh->lh_next = *lhp;
+ 	lh->lh_hash = h;
+ 	lh->lh_cmd = cp;
+@@ -925,8 +1024,8 @@
+ 				continue;
+ 			}
+ 			if (!lh->lh_ref)
+-				warnx("%lu: %s: unused label '%s'",
+-				    linenum, fname, lh->lh_cmd->t);
++                fprintf(stderr, "sed: %lu: %s: unused label '%s'\n", linenum, fname, lh->lh_cmd->t);
++            // warnx("%lu: %s: unused label '%s'", linenum, fname, lh->lh_cmd->t);
+ 			free(lh);
+ 		}
+ 	}
+diff -Naur text_cmds-99/sed/extern.h text_cmds/sed/extern.h
+--- text_cmds-99/sed/extern.h	2005-09-20 23:36:44.000000000 +0200
++++ text_cmds/sed/extern.h	2018-01-10 11:31:02.000000000 +0100
+@@ -40,7 +40,7 @@
+ extern size_t maxnsub;
+ extern u_long linenum;
+ extern int appendnum;
+-extern int aflag, eflag, nflag;
++extern int aflag, eflag, sed_nflag;
+ extern const char *fname, *outfname;
+ extern FILE *infile, *outfile;
+ extern int rflags;	/* regex flags to use */
+diff -Naur text_cmds-99/sed/main.c text_cmds/sed/main.c
+--- text_cmds-99/sed/main.c	2005-09-20 23:36:44.000000000 +0200
++++ text_cmds/sed/main.c	2018-01-10 11:31:02.000000000 +0100
+@@ -64,6 +64,9 @@
+ 
+ #include "defs.h"
+ #include "extern.h"
++// iOS changes:
++#include "ios_error.h"
++#include <pthread.h>
+ 
+ /*
+  * Linked list of units (strings and files) to be compiled
+@@ -92,12 +95,12 @@
+  * Linked list pointer to files and pointer to current
+  * next pointer.
+  */
+-static struct s_flist *files, **fl_nextp = &files;
++static struct s_flist *files = NULL, **fl_nextp = &files;
+ 
+ FILE *infile;			/* Current input file */
+ FILE *outfile;			/* Current output file */
+ 
+-int aflag, eflag, nflag;
++int aflag, eflag, sed_nflag;
+ int rflags = 0;
+ static int rval;		/* Exit status */
+ 
+@@ -118,11 +121,25 @@
+ static void usage(void);
+ 
+ int
+-main(int argc, char *argv[])
++sed_main(int argc, char *argv[])
+ {
+ 	int c, fflag;
+ 	char *temp_arg;
+ 
++    // init all flags:
++    aflag = eflag = sed_nflag = rflags = 0;
++    infile = NULL;
++    outfile = NULL;
++    fl_nextp = &files;
++    if (files != NULL) {
++        while (files != NULL) { struct s_flist *next = files->next; free(files); files = next; }
++    }
++    cu_nextp = &script;
++    if (script != NULL) {
++        while (script != NULL) { struct s_compunit *next = script->next; free(script); script = next; }
++    }
++    rval = 0;        /* Exit status */
++
+ 	(void) setlocale(LC_ALL, "");
+ 
+ 	fflag = 0;
+@@ -139,7 +156,7 @@
+ 		case 'e':
+ 			eflag = 1;
+ 			if ((temp_arg = malloc(strlen(optarg) + 2)) == NULL)
+-				err(1, "malloc");
++                fprintf(stderr, "sed: malloc: %s\n", strerror(errno)); // err(1, "malloc");
+ 			strcpy(temp_arg, optarg);
+ 			strcat(temp_arg, "\n");
+ 			add_compunit(CU_STRING, temp_arg);
+@@ -153,10 +170,10 @@
+ 			break;
+ 		case 'l':
+ 			if(setlinebuf(stdout) != 0)
+-				warnx("setlinebuf() failed");
++                fprintf(stderr, "sed: setlinebuf() failed\n"); // warnx("setlinebuf() failed");
+ 			break;
+ 		case 'n':
+-			nflag = 1;
++			sed_nflag = 1;
+ 			break;
+ 		default:
+ 		case '?':
+@@ -181,9 +198,12 @@
+ 		add_file(NULL);
+ 	process();
+ 	cfclose(prog, NULL);
+-	if (fclose(stdout))
+-		err(1, "stdout");
+-	exit(rval);
++	// if (fclose(stdout))
++	//	err(1, "stdout");
++	// exit(rval);
++    if ((infile != NULL) && (infile != stdin)) fclose(infile);
++    if ((outfile != NULL) && (outfile != stdout)) fclose(outfile);
++    return 0;
+ }
+ 
+ static void
+@@ -192,7 +212,8 @@
+ 	(void)fprintf(stderr, "%s\n%s\n",
+ 		"usage: sed script [-Ealn] [-i extension] [file ...]",
+ 		"       sed [-Ealn] [-i extension] [-e script] ... [-f script_file] ... [file ...]");
+-	exit(1);
++    pthread_exit(NULL);
++	// exit(1);
+ }
+ 
+ /*
+@@ -220,7 +241,7 @@
+ 		switch (script->type) {
+ 		case CU_FILE:
+ 			if ((f = fopen(script->s, "r")) == NULL)
+-				err(1, "%s", script->s);
++                fprintf(stderr, "sed: %s: %s\n", script->s, strerror(errno)); // err(1, "%s", script->s);
+ 			fname = script->s;
+ 			state = ST_FILE;
+ 			goto again;
+@@ -239,7 +260,7 @@
+ 		if ((p = fgets(buf, n, f)) != NULL) {
+ 			linenum++;
+ 			if (linenum == 1 && buf[0] == '#' && buf[1] == 'n')
+-				nflag = 1;
++				sed_nflag = 1;
+ 			if (more != NULL)
+ 				*more = !feof(f);
+ 			return (p);
+@@ -250,7 +271,7 @@
+ 		goto again;
+ 	case ST_STRING:
+ 		if (linenum == 0 && s[0] == '#' && s[1] == 'n')
+-			nflag = 1;
++			sed_nflag = 1;
+ 		p = buf;
+ 		for (;;) {
+ 			if (n-- <= 1) {
+@@ -308,7 +329,7 @@
+ 		/* stdin? */
+ 		if (files->fname == NULL) {
+ 			if (inplace != NULL)
+-				errx(1, "-i may not be used with stdin");
++                fprintf(stderr, "sed: -i may not be used with stdin\n"); //errx(1, "-i may not be used with stdin");
+ 			infile = stdin;
+ 			fname = "stdin";
+ 			outfile = stdout;
+@@ -328,12 +349,13 @@
+ 			return (0);
+ 		}
+ 		if (infile != NULL) {
+-			fclose(infile);
++			if (infile != stdin) fclose(infile);
+ 			if (*oldfname != '\0') {
+ 				if (rename(fname, oldfname) != 0) {
+-					warn("rename()");
++                    fprintf(stderr, "sed: rename(): %s\n", strerror(errno)); // warn("rename()");
+ 					unlink(tmpfname);
+-					exit(1);
++                    pthread_exit(NULL);
++					// exit(1);
+ 				}
+ 				*oldfname = '\0';
+ 			}
+@@ -357,27 +379,32 @@
+ 		fname = files->fname;
+ 		if (inplace != NULL) {
+ 			if (lstat(fname, &sb) != 0)
+-				err(1, "%s", fname);
++                fprintf(stderr, "sed: %s: %s\n", fname, strerror(errno)); // err(1, "%s", fname);
+ 			if (!(sb.st_mode & S_IFREG))
+-				errx(1, "%s: %s %s", fname,
+-				    "in-place editing only",
+-				    "works for regular files");
++                fprintf(stderr, "sed: %s: %s %s\n", fname,
++                     "in-place editing only",
++                     "works for regular files");
++				//errx(1, "%s: %s %s", fname,
++				//    "in-place editing only",
++				//    "works for regular files");
+ 			if (*inplace != '\0') {
+ 				strlcpy(oldfname, fname,
+ 				    sizeof(oldfname));
+ 				len = strlcat(oldfname, inplace,
+ 				    sizeof(oldfname));
+ 				if (len > sizeof(oldfname))
+-					errx(1, "%s: name too long", fname);
++                    fprintf(stderr, "sed: %s: name too long\n", fname);
++                // errx(1, "%s: name too long", fname);
+ 			}
+ 			len = snprintf(tmpfname, sizeof(tmpfname),
+ 			    "%s/.!%ld!%s", dirname(fname), (long)getpid(),
+ 			    basename(fname));
+ 			if (len >= sizeof(tmpfname))
+-				errx(1, "%s: name too long", fname);
++                fprintf(stderr, "sed: %s: name too long\n", fname);
++				// errx(1, "%s: name too long", fname);
+ 			unlink(tmpfname);
+ 			if ((outfile = fopen(tmpfname, "w")) == NULL)
+-				err(1, "%s", fname);
++                fprintf(stderr, "sed: %s: %s\n", fname, strerror(errno)); // err(1, "%s", fname);
+ 			fchown(fileno(outfile), sb.st_uid, sb.st_gid);
+ 			fchmod(fileno(outfile), sb.st_mode & ALLPERMS);
+ 			outfname = tmpfname;
+@@ -386,7 +413,7 @@
+ 			outfname = "stdout";
+ 		}
+ 		if ((infile = fopen(fname, "r")) == NULL) {
+-			warn("%s", fname);
++            fprintf(stderr, "sed: %s: %s\n", fname, strerror(errno)); // warn("%s", fname);
+ 			rval = 1;
+ 			continue;
+ 		}
+@@ -401,7 +428,8 @@
+ 	 */
+ 	p = fgetln(infile, &len);
+ 	if (ferror(infile))
+-		errx(1, "%s: %s", fname, strerror(errno ? errno : EIO));
++        fprintf(stderr, "sed: %s: %s\n", fname, strerror(errno ? errno : EIO));
++        // errx(1, "%s: %s", fname, strerror(errno ? errno : EIO));
+ 	if (len != 0 && p[len - 1] == '\n')
+ 		len--;
+ 	cspace(sp, p, len, spflag);
+@@ -420,7 +448,7 @@
+ 	struct s_compunit *cu;
+ 
+ 	if ((cu = malloc(sizeof(struct s_compunit))) == NULL)
+-		err(1, "malloc");
++        fprintf(stderr, "sed: malloc: %s\n", strerror(errno)); // err(1, "malloc");
+ 	cu->type = type;
+ 	cu->s = s;
+ 	cu->next = NULL;
+@@ -437,8 +465,9 @@
+ 	struct s_flist *fp;
+ 
+ 	if ((fp = malloc(sizeof(struct s_flist))) == NULL)
+-		err(1, "malloc");
++        fprintf(stderr, "sed: malloc: %s\n", strerror(errno)); // err(1, "malloc");
+ 	fp->next = NULL;
++    // That's the stuff:
+ 	*fl_nextp = fp;
+ 	fp->fname = s;
+ 	fl_nextp = &fp->next;
+diff -Naur text_cmds-99/sed/misc.c text_cmds/sed/misc.c
+--- text_cmds-99/sed/misc.c	2005-09-20 23:36:44.000000000 +0200
++++ text_cmds/sed/misc.c	2018-01-10 11:31:02.000000000 +0100
+@@ -49,6 +49,9 @@
+ 
+ #include "defs.h"
+ #include "extern.h"
++// iOS
++#include <errno.h>
++#include "ios_error.h"
+ 
+ /*
+  * Return a string for a regular expression error passed.  This is overkill,
+@@ -65,7 +68,7 @@
+ 		free(oe);
+ 	s = regerror(errcode, preg, NULL, 0);
+ 	if ((oe = malloc(s)) == NULL)
+-		err(1, "malloc");
++        fprintf(stderr, "sed: malloc: %s\n", strerror(errno)); // err(1, "malloc");
+ 	(void)regerror(errcode, preg, oe, s);
+ 	return (oe);
+ }
+diff -Naur text_cmds-99/sed/process.c text_cmds/sed/process.c
+--- text_cmds-99/sed/process.c	2005-09-20 23:36:44.000000000 +0200
++++ text_cmds/sed/process.c	2018-01-10 11:31:02.000000000 +0100
+@@ -58,6 +58,7 @@
+ 
+ #include "defs.h"
+ #include "extern.h"
++#include "ios_error.h"
+ 
+ static SPACE HS, PS, SS, YS;
+ #define	pd		PS.deleted
+@@ -116,7 +117,7 @@
+ 					if ((appends = realloc(appends,
+ 					    sizeof(struct s_appends) *
+ 					    (appendnum *= 2))) == NULL)
+-						err(1, "realloc");
++                        fprintf(stderr, "sed: realloc: %s\n", strerror(errno)); // err(1, "realloc");
+ 				appends[appendx].type = AP_STRING;
+ 				appends[appendx].s = cp->t;
+ 				appends[appendx].len = strlen(cp->t);
+@@ -167,7 +168,7 @@
+ 				lputs(ps, psl);
+ 				break;
+ 			case 'n':
+-				if (!nflag && !pd)
++				if (!sed_nflag && !pd)
+ 					OUT(ps)
+ 				flush_appends();
+ 				if (!mf_fgets(&PS, REPLACE))
+@@ -198,7 +199,7 @@
+ 					psl = oldpsl;
+ 				break;
+ 			case 'q':
+-				if (!nflag && !pd)
++				if (!sed_nflag && !pd)
+ 					OUT(ps)
+ 				flush_appends();
+ 				lseek(STDIN_FILENO, ftell(stdin), SEEK_SET);
+@@ -208,7 +209,7 @@
+ 					if ((appends = realloc(appends,
+ 					    sizeof(struct s_appends) *
+ 					    (appendnum *= 2))) == NULL)
+-						err(1, "realloc");
++						        fprintf(stderr, "sed: realloc: %s\n", strerror(errno)); // err(1, "realloc");
+ 				appends[appendx].type = AP_FILE;
+ 				appends[appendx].s = cp->t;
+ 				appends[appendx].len = strlen(cp->t);
+@@ -230,10 +231,10 @@
+ 				if (cp->u.fd == -1 && (cp->u.fd = open(cp->t,
+ 				    O_WRONLY|O_APPEND|O_CREAT|O_TRUNC,
+ 				    DEFFILEMODE)) == -1)
+-					err(1, "%s", cp->t);
++                    fprintf(stderr, "sed: %s: %s\n", cp->t, strerror(errno)); // err(1, "%s", cp->t);
+ 				if (write(cp->u.fd, ps, psl) != psl ||
+ 				    write(cp->u.fd, "\n", 1) != 1)
+-					err(1, "%s", cp->t);
++                    fprintf(stderr, "sed: %s: %s\n", cp->t, strerror(errno)); // err(1, "%s", cp->t);
+ 				break;
+ 			case 'x':
+ 				if (hs == NULL)
+@@ -256,7 +257,7 @@
+ 			cp = cp->next;
+ 		} /* for all cp */
+ 
+-new:		if (!nflag && !pd)
++new:		if (!sed_nflag && !pd)
+ 			OUT(ps)
+ 		flush_appends();
+ 	} /* for all lines */
+@@ -329,8 +330,10 @@
+ 	if (re == NULL) {
+ 		if (defpreg != NULL && cp->u.s->maxbref > defpreg->re_nsub) {
+ 			linenum = cp->u.s->linenum;
+-			errx(1, "%lu: %s: \\%d not defined in the RE",
++            fprintf(stderr, "sed: %lu: %s: \\%d not defined in the RE\n",
++			// errx(1, "%lu: %s: \\%d not defined in the RE",
+ 					linenum, fname, cp->u.s->maxbref);
++            pthread_exit(NULL);
+ 		}
+ 	}
+ 	if (!regexec_e(re, s, 0, 0, psl))
+@@ -414,10 +417,10 @@
+ 	if (cp->u.s->wfile && !pd) {
+ 		if (cp->u.s->wfd == -1 && (cp->u.s->wfd = open(cp->u.s->wfile,
+ 		    O_WRONLY|O_APPEND|O_CREAT|O_TRUNC, DEFFILEMODE)) == -1)
+-			err(1, "%s", cp->u.s->wfile);
++            fprintf(stderr, "sed: %s: %s\n", cp->u.s->wfile, strerror(errno)); // err(1, "%s", cp->u.s->wfile);
+ 		if (write(cp->u.s->wfd, ps, psl) != psl ||
+ 		    write(cp->u.s->wfd, "\n", 1) != 1)
+-			err(1, "%s", cp->u.s->wfile);
++            fprintf(stderr, "sed: %s: %s\n", cp->u.s->wfile, strerror(errno)); // err(1, "%s", cp->u.s->wfile);
+ 	}
+ 	return (1);
+ }
+@@ -511,7 +514,10 @@
+ 			break;
+ 		}
+ 	if (ferror(outfile))
+-		errx(1, "%s: %s", outfname, strerror(errno ? errno : EIO));
++    { fprintf(stderr, "sed: %s: %s\n", outfname, strerror(errno ? errno : EIO));
++        pthread_exit(NULL);
++    // errx(1, "%s: %s", outfname, strerror(errno ? errno : EIO));
++    }
+ 	appendx = sdone = 0;
+ }
+ 
+@@ -589,8 +595,11 @@
+ 		fprintf(outfile, "\\\n");
+ 	(void)fputc('$', outfile);
+ 	(void)fputc('\n', outfile);
+-	if (ferror(outfile))
+-		errx(1, "%s: %s", outfname, strerror(errno ? errno : EIO));
++    if (ferror(outfile)) {
++        fprintf(stderr, "sed: %s: %s\n", outfname, strerror(errno ? errno : EIO));
++        // errx(1, "%s: %s", outfname, strerror(errno ? errno : EIO));
++        pthread_exit(NULL);
++    }
+ }
+ 
+ static __inline int
+@@ -601,7 +610,10 @@
+ 
+ 	if (preg == NULL) {
+ 		if (defpreg == NULL)
+-			errx(1, "first RE may not be empty");
++        { fprintf(stderr, "sed: first RE may not be empty\n");
++            // errx(1, "first RE may not be empty");
++            pthread_exit(NULL);
++        }
+ 	} else
+ 		defpreg = preg;
+ 
+@@ -617,7 +629,9 @@
+ 	case REG_NOMATCH:
+ 		return (0);
+ 	}
+-	errx(1, "RE error: %s", strregerror(eval, defpreg));
++    fprintf(stderr, "sed: RE error: %s\n", strregerror(eval, defpreg));
++    pthread_exit(NULL);
++    // errx(1, "RE error: %s", strregerror(eval, defpreg));
+ 	/* NOTREACHED */
+ }
+ 
+@@ -637,9 +651,10 @@
+ 		sp->blen += (reqlen) + 1024;				\
+ 		if ((sp->space = sp->back = realloc(sp->back, sp->blen)) \
+ 		    == NULL)						\
+-			err(1, "realloc");				\
++            fprintf(stderr, "sed: realloc: %s\n", strerror(errno)); \
+ 		dst = sp->space + sp->len;				\
+ 	}
++    // err(1, "realloc");
+ 
+ 	dst = sp->space + sp->len;
+ 	while ((c = *src++) != '\0') {
+@@ -683,7 +698,7 @@
+ 		sp->blen = tlen + 1024;
+ 		if ((sp->space = sp->back = realloc(sp->back, sp->blen)) ==
+ 		    NULL)
+-			err(1, "realloc");
++			        fprintf(stderr, "sed: realloc: %s\n", strerror(errno)); // err(1, "realloc");
+ 	}
+ 
+ 	if (spflag == REPLACE)
+@@ -705,12 +720,12 @@
+ 		switch(cp->code) {
+ 		case 's':
+ 			if (cp->u.s->wfd != -1 && close(cp->u.s->wfd))
+-				err(1, "%s", cp->u.s->wfile);
++                fprintf(stderr, "sed: %s: %s\n", cp->u.s->wfile, strerror(errno)); // err(1, "%s", cp->u.s->wfile);
+ 			cp->u.s->wfd = -1;
+ 			break;
+ 		case 'w':
+ 			if (cp->u.fd != -1 && close(cp->u.fd))
+-				err(1, "%s", cp->t);
++                fprintf(stderr, "sed: %s: %s\n", cp->t, strerror(errno)); // err(1, "%s", cp->t);
+ 			cp->u.fd = -1;
+ 			break;
+ 		case '{':
 diff -Naur text_cmds-99/wc/wc.c text_cmds/wc/wc.c
 --- text_cmds-99/wc/wc.c	2008-02-26 02:39:32.000000000 +0100
-+++ text_cmds/wc/wc.c	2017-12-12 23:58:22.000000000 +0100
++++ text_cmds/wc/wc.c	2018-01-10 11:31:02.000000000 +0100
 @@ -51,7 +51,7 @@
  #include <sys/stat.h>
  
@@ -624,7 +1855,7 @@ diff -Naur text_cmds-99/wc/wc.c text_cmds/wc/wc.c
  	} else {
  		if ((fd = open(file, O_RDONLY, 0)) < 0) {
 -			warn("%s: open", file);
-+            fprintf(stderr, "wc: %s: open\n", file);
++            fprintf(stderr, "wc: %s: open: %s\n", file, strerror(errno));
 +			// warn("%s: open", file);
  			return (1);
  		}
@@ -634,7 +1865,7 @@ diff -Naur text_cmds-99/wc/wc.c text_cmds/wc/wc.c
  		while ((len = read(fd, buf, buf_size))) {
  			if (len == -1) {
 -				warn("%s: read", file);
-+                fprintf(stderr, "wc: %s: read\n", file);
++                fprintf(stderr, "wc: %s: read: %s\n", file, strerror(errno));
 +                // warn("%s: read", file);
  				(void)close(fd);
  				return (1);
@@ -644,7 +1875,7 @@ diff -Naur text_cmds-99/wc/wc.c text_cmds/wc/wc.c
  	if (dochar || domulti) {
  		if (fstat(fd, &sb)) {
 -			warn("%s: fstat", file);
-+            fprintf(stderr, "wc: %s: fstat\n", file);
++            fprintf(stderr, "wc: %s: fstat: %s\n", file, strerror(errno));
 +            // warn("%s: fstat", file);
  			(void)close(fd);
  			return (1);
@@ -654,7 +1885,7 @@ diff -Naur text_cmds-99/wc/wc.c text_cmds/wc/wc.c
  	while ((len = read(fd, buf, buf_size)) != 0) {
  		if (len == -1) {
 -			warn("%s: read", file);
-+            fprintf(stderr, "wc: %s: read\n", file);
++            fprintf(stderr, "wc: %s: read: %s\n", file, strerror(errno));
 +            // warn("%s: read", file);
  			(void)close(fd);
  			return (1);
@@ -664,7 +1895,7 @@ diff -Naur text_cmds-99/wc/wc.c text_cmds/wc/wc.c
  				if (!warned) {
  					errno = EILSEQ;
 -					warn("%s", file);
-+                    fprintf(stderr, "wc: %s\n", file);
++                    fprintf(stderr, "wc: %s: %s\n", file, strerror(errno));
 +                    // warn("%s", file);
  					warned = 1;
  				}
@@ -674,7 +1905,7 @@ diff -Naur text_cmds-99/wc/wc.c text_cmds/wc/wc.c
  	if (domulti && MB_CUR_MAX > 1)
  		if (mbrtowc(NULL, NULL, 0, &mbs) == (size_t)-1 && !warned)
 -			warn("%s", file);
-+            fprintf(stderr, "wc: %s\n", file);
++            fprintf(stderr, "wc: %s: %s\n", file, strerror(errno));
 +            // warn("%s", file);
  	if (doline) {
  		tlinect += linect;

--- a/Dependencies/ios_system/text_cmds/cat/cat.c
+++ b/Dependencies/ios_system/text_cmds/cat/cat.c
@@ -156,7 +156,7 @@ scanfiles(char *argv[], int cooked)
 #endif
 		}
 		if (fd < 0) {
-            fprintf(stderr, "cat: %s\n", path);
+            fprintf(stderr, "cat: %s: %s\n", path, strerror(errno));
             // warn("%s", path);
 			rval = 1;
 		} else if (cooked) {
@@ -231,14 +231,14 @@ cook_cat(FILE *fp)
 			break;
 	}
 	if (ferror(fp)) {
-        fprintf(stderr, "cat: %s\n", filename);
+        fprintf(stderr, "cat: %s: %s\n", filename, strerror(errno));
         // warn("%s", filename);
 		rval = 1;
 		clearerr(fp);
 	}
     if (ferror(stdout)) {
 		// err(1, "stdout");
-        fprintf(stderr, "cat: stdout\n");
+        fprintf(stderr, "cat: stdout: %s\n", strerror(errno));
         pthread_exit(NULL);
     }
 }
@@ -259,7 +259,7 @@ raw_cat(int rfd)
         bsize = 1024; // MAX(sbuf.st_blksize, 1024);
         if ((buf = malloc(bsize)) == NULL) {
             // err(1, "buffer");
-            fprintf(stderr, "cat: buffer\n");
+            fprintf(stderr, "cat: buffer: %s\n", strerror(errno));
             pthread_exit(NULL);
         }
 	}
@@ -274,7 +274,7 @@ raw_cat(int rfd)
 			// if ((nw = write(wfd, buf + off, (size_t)nr)) < 0) err(1, "stdout");
         }
 	if (nr < 0) {
-        fprintf(stderr, "cat: %s\n", filename);
+        fprintf(stderr, "cat: %s: %s\n", filename, strerror(errno));
         // warn("%s", filename);
 		rval = 1;
 	}
@@ -319,12 +319,12 @@ udom_open(const char *path, int flags)
 		switch(flags & O_ACCMODE) {
 		case O_RDONLY:
 			if (shutdown(fd, SHUT_WR) == -1)
-				fprintf(stderr, "\n");
+                fprintf(stderr, "cat: %s\n", strerror(errno));
                 // warn(NULL);
 			break;
 		case O_WRONLY:
 			if (shutdown(fd, SHUT_RD) == -1)
-                fprintf(stderr, "\n");
+                fprintf(stderr, "cat: %s\n", strerror(errno));
 				// warn(NULL);
 			break;
 		default:

--- a/Dependencies/ios_system/text_cmds/ed/buf.c
+++ b/Dependencies/ios_system/text_cmds/ed/buf.c
@@ -33,6 +33,10 @@ __FBSDID("$FreeBSD: src/bin/ed/buf.c,v 1.22 2002/06/30 05:13:53 obrien Exp $");
 #include <sys/stat.h>
 
 #include "ed.h"
+// from ios_system:
+#include "ios_error.h"
+#include <pthread.h>
+#import <Foundation/Foundation.h>
 
 
 FILE *sfp;				/* scratch file pointer */
@@ -185,7 +189,7 @@ get_addressed_line_node(long n)
 
 extern int newline_added;
 
-char sfn[15] = "";				/* scratch file name */
+char sfn[PATH_MAX] = "";				/* scratch file name */
 
 /* open_sbuf: open scratch file */
 int
@@ -196,7 +200,10 @@ open_sbuf(void)
 
 	isbinary = newline_added = 0;
 	u = umask(077);
-	strcpy(sfn, "/tmp/ed.XXXXXX");
+    // getenv($HOME) + "/tmp/" or NSString * NSTemporaryDirectory(void);
+    // the latter, I guess.
+    sprintf(sfn, "%s/ed.XXXXXX", NSTemporaryDirectory().UTF8String);
+	// strcpy(sfn, "/tmp/ed.XXXXXX");
 	if ((fd = mkstemp(sfn)) == -1 ||
 	    (sfp = fdopen(fd, "w+")) == NULL) {
 		if (fd != -1)
@@ -237,7 +244,8 @@ quit(int n)
 		fclose(sfp);
 		unlink(sfn);
 	}
-	exit(n);
+	// exit(n);
+    pthread_exit(NULL);
 }
 
 

--- a/Dependencies/ios_system/text_cmds/ed/ed.h
+++ b/Dependencies/ios_system/text_cmds/ed/ed.h
@@ -275,7 +275,7 @@ extern long addr_last;
 extern long current_addr;
 extern const char *errmsg;
 extern long first_addr;
-extern int lineno;
+extern int ed_lineno;
 extern long second_addr;
 extern long u_addr_last;
 extern long u_current_addr;

--- a/Dependencies/ios_system/text_cmds/ed/io.c
+++ b/Dependencies/ios_system/text_cmds/ed/io.c
@@ -267,7 +267,7 @@ get_tty_line(void)
 			if (!(ibuf[i++] = c)) isbinary = 1;
 			if (c != '\n')
 				continue;
-			lineno++;
+			ed_lineno++;
 			ibuf[i] = '\0';
 			ibufp = ibuf;
 			return i;

--- a/Dependencies/ios_system/text_cmds/grep/grep.c
+++ b/Dependencies/ios_system/text_cmds/grep/grep.c
@@ -334,7 +334,7 @@ read_patterns(const char *fn)
 
     if ((f = fopen(fn, "r")) == NULL) {
 		// err(2, "%s", fn);
-        fprintf(stderr, "grep: %s\n", fn);
+        fprintf(stderr, "grep: %s: %s\n", fn, strerror(errno));
         pthread_exit(NULL);
     }
 	if ((fstat(fileno(f), &st) == -1) || (S_ISDIR(st.st_mode))) {
@@ -345,7 +345,7 @@ read_patterns(const char *fn)
 		add_pattern(line, line[0] == '\n' ? 0 : len);
     if (ferror(f)) {
 		// err(2, "%s", fn);
-        fprintf(stderr, "grep: %s\n", fn);
+        fprintf(stderr, "grep: %s: %s\n", fn, strerror(errno));
         pthread_exit(NULL);
     }
 	fclose(f);
@@ -482,6 +482,7 @@ grep_main(int argc, char *argv[])
 				Aflag = 0;
 			else if (Aflag > LLONG_MAX / 10) {
 				errno = ERANGE;
+                fprintf(stderr, "grep: %s\n", strerror(errno));
                 pthread_exit(NULL);
 				// err(2, NULL);
 			}
@@ -499,11 +500,14 @@ grep_main(int argc, char *argv[])
 			errno = 0;
 			l = strtoull(optarg, &ep, 10);
 			if (((errno == ERANGE) && (l == ULLONG_MAX)) ||
-			    ((errno == EINVAL) && (l == 0)))
+                ((errno == EINVAL) && (l == 0))) {
+                fprintf(stderr, "grep: %s\n", strerror(errno));
                 pthread_exit(NULL);
                 // err(2, NULL);
+            }
 			else if (ep[0] != '\0') {
 				errno = EINVAL;
+                fprintf(stderr, "grep: %s\n", strerror(errno));
                 pthread_exit(NULL);
                 // err(2, NULL);
 			}
@@ -584,7 +588,7 @@ grep_main(int argc, char *argv[])
 #ifdef WITHOUT_BZIP2
 			errno = EOPNOTSUPP;
 			// err(2, "bzip2 support was disabled at compile-time");
-            fprintf(stderr, "grep: bzip2 support was disabled at compile-time\n");
+                fprintf(stderr, "grep: bzip2 support was disabled at compile-time: %s\n", strerror(errno));
             pthread_exit(NULL);
 #endif
 			filebehave = FILE_BZIP;
@@ -602,11 +606,14 @@ grep_main(int argc, char *argv[])
 			errno = 0;
 			mcount = strtoll(optarg, &ep, 10);
 			if (((errno == ERANGE) && (mcount == LLONG_MAX)) ||
-			    ((errno == EINVAL) && (mcount == 0)))
+                ((errno == EINVAL) && (mcount == 0))) {
+                fprintf(stderr, "grep: %s\n", strerror(errno));
                 pthread_exit(NULL);
                 // err(2, NULL);
+            }
 			else if (ep[0] != '\0') {
 				errno = EINVAL;
+                fprintf(stderr, "grep: %s\n", strerror(errno));
                 pthread_exit(NULL);
                 // err(2, NULL);
 			}
@@ -615,7 +622,7 @@ grep_main(int argc, char *argv[])
 #ifdef WITHOUT_LZMA
 			errno = EOPNOTSUPP;
 			// err(2, "lzma support was disabled at compile-time");
-            fprintf(stderr, "grep: lzma support was disabled at compile-time\n");
+                fprintf(stderr, "grep: lzma support was disabled at compile-time: %s\n", strerror(errno));
             pthread_exit(NULL);
 #endif
 			filebehave = FILE_LZMA;
@@ -675,7 +682,7 @@ grep_main(int argc, char *argv[])
 #ifdef WITHOUT_LZMA
 			errno = EOPNOTSUPP;
 			// err(2, "xz support was disabled at compile-time");
-            fprintf(stderr, "grep: xz support was disabled at compile-time\n");
+                fprintf(stderr, "grep: xz support was disabled at compile-time: %s\n", strerror(errno));
             pthread_exit(NULL);
 #endif
 			filebehave = FILE_XZ;

--- a/Dependencies/ios_system/text_cmds/grep/util.c
+++ b/Dependencies/ios_system/text_cmds/grep/util.c
@@ -138,7 +138,7 @@ grep_tree(char **argv)
 
     if (!(fts = fts_open(argv, fts_flags, NULL))) {
 		// err(2, "fts_open");
-        fprintf(stderr, "grep: fts_open\n");
+        fprintf(stderr, "grep: fts_open: %s\n", strerror(errno));
         pthread_exit(NULL);
     }
 	while ((p = fts_read(fts)) != NULL) {
@@ -222,7 +222,7 @@ procfile(const char *fn)
 	if (f == NULL) {
 		file_err = true;
 		if (!sflag)
-            fprintf(stderr, "grep: %s\n", fn);
+            fprintf(stderr, "grep: %s: %s\n", fn, strerror(errno));
             // warn("%s", fn);
 		return (0);
 	}
@@ -504,7 +504,7 @@ grep_malloc(size_t size)
 
     if ((ptr = malloc(size)) == NULL) {
 		// err(2, "malloc");
-        fprintf(stderr, "grep: malloc\n");
+        fprintf(stderr, "grep: malloc: %s\n", strerror(errno));
         pthread_exit(NULL);
     }
 	return (ptr);
@@ -520,7 +520,7 @@ grep_calloc(size_t nmemb, size_t size)
 
     if ((ptr = calloc(nmemb, size)) == NULL) {
         // err(2, "calloc");
-        fprintf(stderr, "grep: malloc\n");
+        fprintf(stderr, "grep: calloc: %s\n", strerror(errno));
     pthread_exit(NULL);
 }
 	return (ptr);
@@ -535,7 +535,7 @@ grep_realloc(void *ptr, size_t size)
 
     if ((ptr = realloc(ptr, size)) == NULL) {
         // err(2, "realloc");
-        fprintf(stderr, "grep: realloc\n");
+        fprintf(stderr, "grep: realloc: %s\n", strerror(errno));
         pthread_exit(NULL);
     }
 	return (ptr);
@@ -551,7 +551,7 @@ grep_strdup(const char *str)
 
     if ((ret = strdup(str)) == NULL) {
         // err(2, "strdup");
-        fprintf(stderr, "grep: strdup\n");
+        fprintf(stderr, "grep: strdup: %s\n", strerror(errno));
         pthread_exit(NULL);
     }
 	return (ret);

--- a/Dependencies/ios_system/text_cmds/sed/extern.h
+++ b/Dependencies/ios_system/text_cmds/sed/extern.h
@@ -40,7 +40,7 @@ extern regmatch_t *match;
 extern size_t maxnsub;
 extern u_long linenum;
 extern int appendnum;
-extern int aflag, eflag, nflag;
+extern int aflag, eflag, sed_nflag;
 extern const char *fname, *outfname;
 extern FILE *infile, *outfile;
 extern int rflags;	/* regex flags to use */

--- a/Dependencies/ios_system/text_cmds/sed/misc.c
+++ b/Dependencies/ios_system/text_cmds/sed/misc.c
@@ -49,6 +49,9 @@ static const char sccsid[] = "@(#)misc.c	8.1 (Berkeley) 6/6/93";
 
 #include "defs.h"
 #include "extern.h"
+// iOS
+#include <errno.h>
+#include "ios_error.h"
 
 /*
  * Return a string for a regular expression error passed.  This is overkill,
@@ -65,7 +68,7 @@ strregerror(int errcode, regex_t *preg)
 		free(oe);
 	s = regerror(errcode, preg, NULL, 0);
 	if ((oe = malloc(s)) == NULL)
-		err(1, "malloc");
+        fprintf(stderr, "sed: malloc: %s\n", strerror(errno)); // err(1, "malloc");
 	(void)regerror(errcode, preg, oe, s);
 	return (oe);
 }

--- a/Dependencies/ios_system/text_cmds/wc/wc.c
+++ b/Dependencies/ios_system/text_cmds/wc/wc.c
@@ -165,7 +165,7 @@ cnt(const char *file)
 		fd = STDIN_FILENO;
 	} else {
 		if ((fd = open(file, O_RDONLY, 0)) < 0) {
-            fprintf(stderr, "wc: %s: open\n", file);
+            fprintf(stderr, "wc: %s: open: %s\n", file, strerror(errno));
 			// warn("%s: open", file);
 			return (1);
 		}
@@ -196,7 +196,7 @@ cnt(const char *file)
 	if (doline) {
 		while ((len = read(fd, buf, buf_size))) {
 			if (len == -1) {
-                fprintf(stderr, "wc: %s: read\n", file);
+                fprintf(stderr, "wc: %s: read: %s\n", file, strerror(errno));
                 // warn("%s: read", file);
 				(void)close(fd);
 				return (1);
@@ -221,7 +221,7 @@ cnt(const char *file)
 	 */
 	if (dochar || domulti) {
 		if (fstat(fd, &sb)) {
-            fprintf(stderr, "wc: %s: fstat\n", file);
+            fprintf(stderr, "wc: %s: fstat: %s\n", file, strerror(errno));
             // warn("%s: fstat", file);
 			(void)close(fd);
 			return (1);
@@ -240,7 +240,7 @@ word:	gotsp = 1;
 	memset(&mbs, 0, sizeof(mbs));
 	while ((len = read(fd, buf, buf_size)) != 0) {
 		if (len == -1) {
-            fprintf(stderr, "wc: %s: read\n", file);
+            fprintf(stderr, "wc: %s: read: %s\n", file, strerror(errno));
             // warn("%s: read", file);
 			(void)close(fd);
 			return (1);
@@ -254,7 +254,7 @@ word:	gotsp = 1;
 			    (size_t)-1) {
 				if (!warned) {
 					errno = EILSEQ;
-                    fprintf(stderr, "wc: %s\n", file);
+                    fprintf(stderr, "wc: %s: %s\n", file, strerror(errno));
                     // warn("%s", file);
 					warned = 1;
 				}
@@ -280,7 +280,7 @@ word:	gotsp = 1;
 	}
 	if (domulti && MB_CUR_MAX > 1)
 		if (mbrtowc(NULL, NULL, 0, &mbs) == (size_t)-1 && !warned)
-            fprintf(stderr, "wc: %s\n", file);
+            fprintf(stderr, "wc: %s: %s\n", file, strerror(errno));
             // warn("%s", file);
 	if (doline) {
 		tlinect += linect;

--- a/Terminal/Controller/ViewController.swift
+++ b/Terminal/Controller/ViewController.swift
@@ -142,7 +142,7 @@ class ViewController: UIViewController {
 	func setStdOut() {
 		
 		let fileManager = DocumentManager.shared.fileManager
-		let filePath = fileManager.currentDirectoryPath.appending("/.out.txt")
+		let filePath = NSTemporaryDirectory().appending("out.txt")
 		
 		try? fileManager.removeItem(atPath: filePath)
 
@@ -150,14 +150,14 @@ class ViewController: UIViewController {
 			fileManager.createFile(atPath: filePath, contents: nil, attributes: nil)
 		}
 		
-		freopen(".out.txt", "a+", stdout)
+		freopen(filePath.toCString(), "a+", stdout)
 
 	}
 	
 	func setStdErr() {
 		
 		let fileManager = DocumentManager.shared.fileManager
-		let filePath = fileManager.currentDirectoryPath.appending("/.err.txt")
+		let filePath = NSTemporaryDirectory().appending("err.txt")
 		
 		try? fileManager.removeItem(atPath: filePath)
 		
@@ -165,7 +165,7 @@ class ViewController: UIViewController {
 			fileManager.createFile(atPath: filePath, contents: nil, attributes: nil)
 		}
 		
-		freopen(".err.txt", "a+", stderr)
+		freopen(filePath.toCString(), "a+", stderr)
 		
 	}
 	
@@ -396,7 +396,7 @@ extension ViewController: TerminalProcessor {
 		readFile(stdout)
 		readFile(stderr)
 
-		let errFilePath = fileManager.currentDirectoryPath.appending("/.err.txt")
+		let errFilePath = NSTemporaryDirectory().appending("err.txt")
 
 		if let data = fileManager.contents(atPath: errFilePath) {
 			if let errStr = String(data: data, encoding: .utf8) {
@@ -410,7 +410,7 @@ extension ViewController: TerminalProcessor {
 			}
 		}
 		
-		let filePath = fileManager.currentDirectoryPath.appending("/.out.txt")
+		let filePath = NSTemporaryDirectory().appending("out.txt")
 
 		if let data = fileManager.contents(atPath: filePath) {
 			return String(data: data, encoding: .utf8) ?? ""

--- a/Terminal/Controller/ViewController.swift
+++ b/Terminal/Controller/ViewController.swift
@@ -377,17 +377,6 @@ extension ViewController: TerminalProcessor {
 			return availableCommands().joined(separator: "\n")
 		}
 		
-		if command.hasPrefix("cd") {
-            // TODO: move cd to ios_system
-			let result = cd(command: command)
-            if (result) {
-                updateTitle()
-                return ""
-            } else {
-                return "cd: directory not found, or not allowed"
-            }
-		}
-		
 		setStdOut()
 		setStdErr()
 
@@ -400,13 +389,9 @@ extension ViewController: TerminalProcessor {
 
 		if let data = fileManager.contents(atPath: errFilePath) {
 			if let errStr = String(data: data, encoding: .utf8) {
-				
-				let filtered = errStr.replacingOccurrences(of: "Command after parsing: ", with: "")
-				
-				if !filtered.isEmpty {
-					return filtered
-				}
-				
+                if (!errStr.isEmpty) {
+                    return errStr;
+                }
 			}
 		}
 		

--- a/Terminal/Controller/ViewController.swift
+++ b/Terminal/Controller/ViewController.swift
@@ -146,6 +146,7 @@ class ViewController: UIViewController {
 	}
 	
 	func readFile(_ file: UnsafeMutablePointer<FILE>) {
+        
 		let bufsize = 4096
 		let buffer = [CChar](repeating: 0, count: bufsize)
 
@@ -297,7 +298,12 @@ extension ViewController: TerminalProcessor {
 	@discardableResult
 	func process(command: String) -> String {
 
-		let fileManager = DocumentManager.shared.fileManager
+        // Get the window column size (for ls and other commands):
+        let fontSize = ("m" as NSString).size(withAttributes: [NSAttributedStringKey.font: self.terminalView.textView.font])
+        let numColumns = String(describing: Int(floor(self.terminalView.textView.frame.size.width / fontSize.width) - 1))
+        setenv("COLUMNS", numColumns, 1); // force rewrite of value
+        
+        let fileManager = DocumentManager.shared.fileManager
 
 		if command == "help" || command == "?" {
 			return availableCommands().joined(separator: "\n")
@@ -311,7 +317,7 @@ extension ViewController: TerminalProcessor {
 
 			return result
 		}
-		
+        
 		setStdOut()
 		setStdErr()
 

--- a/Terminal/Controller/ViewController.swift
+++ b/Terminal/Controller/ViewController.swift
@@ -58,6 +58,7 @@ class ViewController: UIViewController {
 		
 		NotificationCenter.default.addObserver(self, selector: #selector(applicationDidEnterBackground), name: .UIApplicationDidEnterBackground, object: nil)
 
+        initializeEnvironment();
 	}
 	
 	override func viewWillAppear(_ animated: Bool) {
@@ -320,9 +321,9 @@ extension ViewController {
 }
 
 extension ViewController {
-	
-	func cd(command: String) -> String {
-		
+    
+	func cd(command: String) -> Bool {
+
 		let fileManager = DocumentManager.shared.fileManager
 		
 		var arguments = command.split(separator: " ")
@@ -336,10 +337,10 @@ extension ViewController {
 				let dirPath = URL(fileURLWithPath: fileManager.currentDirectoryPath).deletingLastPathComponent()
 				
 				if dirPath.lastPathComponent == "iCloud~com~silverfox~Terminal" {
-					return ""
+					return true
 				}
 				
-				fileManager.changeCurrentDirectoryPath(dirPath.path)
+				return fileManager.changeCurrentDirectoryPath(dirPath.path)
 				
 			} else if folderName.hasPrefix("/") {
 				
@@ -347,19 +348,19 @@ extension ViewController {
 				
 				let dirPath = documents.appendingPathComponent(String(folderName)).path
 				
-				fileManager.changeCurrentDirectoryPath(dirPath)
+				return fileManager.changeCurrentDirectoryPath(dirPath)
 				
 			} else {
 				
 				let dirPath = fileManager.currentDirectoryPath.appending("/\(folderName)")
 				
-				fileManager.changeCurrentDirectoryPath(dirPath)
+				return fileManager.changeCurrentDirectoryPath(dirPath)
 				
 			}
-			
-			return ""
 		} else {
-			return ""
+            // command is just "cd", we go home, that is the Documents folder
+            let documents = DocumentManager.shared.activeDocumentsFolderURL
+            return fileManager.changeCurrentDirectoryPath(documents.path)
 		}
 		
 	}
@@ -383,12 +384,14 @@ extension ViewController: TerminalProcessor {
 		}
 		
 		if command.hasPrefix("cd") {
-			
+            // TODO: move cd to ios_system
 			let result = cd(command: command)
-			
-			updateTitle()
-
-			return result
+            if (result) {
+                updateTitle()
+                return ""
+            } else {
+                return "cd: directory not found, or not allowed"
+            }
 		}
         
 		setStdOut()
@@ -399,14 +402,29 @@ extension ViewController: TerminalProcessor {
 		readFile(stdout)
 		readFile(stderr)
 
-		let errFilePath = fileManager.currentDirectoryPath.appending("/.err.txt")
+        // This is not fully satisfying, because a command can return both error and standard output (curl, for example)
+        // But not easy to make this robust without streams
+        let errFilePath = fileManager.currentDirectoryPath.appending("/.err.txt")
+        
+        if let data = fileManager.contents(atPath: errFilePath) {
+            if let errStr = String(data: data, encoding: .utf8) {
+                
+                let filtered = errStr.replacingOccurrences(of: "Command after parsing: ", with: "")
+                
+                if !filtered.isEmpty {
+                    return filtered
+                }
+                
+            }
+        }
+        
         let filePath = fileManager.currentDirectoryPath.appending("/.out.txt")
-        let dataErr = fileManager.contents(atPath: errFilePath) ?? nil
-        let data = fileManager.contents(atPath: filePath) ?? nil
-        let errStr = String(data: dataErr!, encoding: .utf8) ?? ""
-        let outStr = String(data: data!, encoding: .utf8) ?? ""
-		
-		return errStr + outStr
+        
+        if let data = fileManager.contents(atPath: filePath) {
+            return String(data: data, encoding: .utf8) ?? ""
+        }
+        
+		return ""
 	}
 	
 }

--- a/Terminal/Controller/ViewController.swift
+++ b/Terminal/Controller/ViewController.swift
@@ -170,7 +170,6 @@ class ViewController: UIViewController {
 	}
 	
 	func readFile(_ file: UnsafeMutablePointer<FILE>) {
-        
 		let bufsize = 4096
 		let buffer = [CChar](repeating: 0, count: bufsize)
 
@@ -372,12 +371,7 @@ extension ViewController: TerminalProcessor {
 	@discardableResult
 	func process(command: String) -> String {
 
-        // Get the window column size (for ls and other commands):
-        let fontSize = ("m" as NSString).size(withAttributes: [NSAttributedStringKey.font: self.terminalView.textView.font])
-        let numColumns = String(describing: Int(floor(self.terminalView.textView.frame.size.width / fontSize.width) - 1))
-        setenv("COLUMNS", numColumns, 1); // force rewrite of value
-        
-        let fileManager = DocumentManager.shared.fileManager
+		let fileManager = DocumentManager.shared.fileManager
 
 		if command == "help" || command == "?" {
 			return availableCommands().joined(separator: "\n")
@@ -393,7 +387,7 @@ extension ViewController: TerminalProcessor {
                 return "cd: directory not found, or not allowed"
             }
 		}
-        
+		
 		setStdOut()
 		setStdErr()
 
@@ -402,28 +396,26 @@ extension ViewController: TerminalProcessor {
 		readFile(stdout)
 		readFile(stderr)
 
-        // This is not fully satisfying, because a command can return both error and standard output (curl, for example)
-        // But not easy to make this robust without streams
-        let errFilePath = fileManager.currentDirectoryPath.appending("/.err.txt")
-        
-        if let data = fileManager.contents(atPath: errFilePath) {
-            if let errStr = String(data: data, encoding: .utf8) {
-                
-                let filtered = errStr.replacingOccurrences(of: "Command after parsing: ", with: "")
-                
-                if !filtered.isEmpty {
-                    return filtered
-                }
-                
-            }
-        }
-        
-        let filePath = fileManager.currentDirectoryPath.appending("/.out.txt")
-        
-        if let data = fileManager.contents(atPath: filePath) {
-            return String(data: data, encoding: .utf8) ?? ""
-        }
-        
+		let errFilePath = fileManager.currentDirectoryPath.appending("/.err.txt")
+
+		if let data = fileManager.contents(atPath: errFilePath) {
+			if let errStr = String(data: data, encoding: .utf8) {
+				
+				let filtered = errStr.replacingOccurrences(of: "Command after parsing: ", with: "")
+				
+				if !filtered.isEmpty {
+					return filtered
+				}
+				
+			}
+		}
+		
+		let filePath = fileManager.currentDirectoryPath.appending("/.out.txt")
+
+		if let data = fileManager.contents(atPath: filePath) {
+			return String(data: data, encoding: .utf8) ?? ""
+		}
+		
 		return ""
 	}
 	

--- a/Terminal/Controller/ViewController.swift
+++ b/Terminal/Controller/ViewController.swift
@@ -126,7 +126,6 @@ class ViewController: UIViewController {
 			return []
 		}
 		
-		arr.append("cd")
 		arr.append("clear")
 		arr.append("help")
 
@@ -382,6 +381,7 @@ extension ViewController: TerminalProcessor {
 
 		ios_system(command.utf8CString)
 
+        updateTitle()
 		readFile(stdout)
 		readFile(stderr)
 

--- a/Terminal/Controller/ViewController.swift
+++ b/Terminal/Controller/ViewController.swift
@@ -321,26 +321,13 @@ extension ViewController: TerminalProcessor {
 		readFile(stderr)
 
 		let errFilePath = fileManager.currentDirectoryPath.appending("/.err.txt")
-
-		if let data = fileManager.contents(atPath: errFilePath) {
-			if let errStr = String(data: data, encoding: .utf8) {
-				
-				let filtered = errStr.replacingOccurrences(of: "Command after parsing: ", with: "")
-				
-				if !filtered.isEmpty {
-					return filtered
-				}
-				
-			}
-		}
+        let filePath = fileManager.currentDirectoryPath.appending("/.out.txt")
+        let dataErr = fileManager.contents(atPath: errFilePath) ?? nil
+        let data = fileManager.contents(atPath: filePath) ?? nil
+        let errStr = String(data: dataErr!, encoding: .utf8) ?? ""
+        let outStr = String(data: data!, encoding: .utf8) ?? ""
 		
-		let filePath = fileManager.currentDirectoryPath.appending("/.out.txt")
-
-		if let data = fileManager.contents(atPath: filePath) {
-			return String(data: data, encoding: .utf8) ?? ""
-		}
-		
-		return ""
+		return errStr + outStr
 	}
 	
 }

--- a/Terminal/Util/DocumentManager.swift
+++ b/Terminal/Util/DocumentManager.swift
@@ -49,11 +49,9 @@ class DocumentManager {
 		} else {
 			return localDocumentsURL
 		}
-        return localDocumentsURL
 	}
 	
 	var iCloudAvailable: Bool {
-        return false
 		return fileManager.ubiquityIdentityToken != nil
 	}
 

--- a/Terminal/Util/DocumentManager.swift
+++ b/Terminal/Util/DocumentManager.swift
@@ -42,10 +42,11 @@ class DocumentManager {
 	var activeDocumentsFolderURL: URL? {
 		
 		if iCloudAvailable {
-			return cloudDocumentsURL
-		} else {
-			return localDocumentsURL
+            if (cloudDocumentsURL != nil) {
+                return cloudDocumentsURL
+            }
 		}
+        return localDocumentsURL
 	}
 	
 	var iCloudAvailable: Bool {

--- a/Terminal/Util/DocumentManager.swift
+++ b/Terminal/Util/DocumentManager.swift
@@ -50,6 +50,7 @@ class DocumentManager {
 	}
 	
 	var iCloudAvailable: Bool {
+        return false
 		return fileManager.ubiquityIdentityToken != nil
 	}
 

--- a/Terminal/View/TerminalView.swift
+++ b/Terminal/View/TerminalView.swift
@@ -168,7 +168,7 @@ extension TerminalView: UITextViewDelegate {
 	}
 	
 	func textView(_ textView: UITextView, shouldChangeTextIn range: NSRange, replacementText text: String) -> Bool {
-		
+        
 		let i = textView.text.distance(from: textView.text.startIndex, to: currentCommandStartIndex)
 		
 		if range.location < i {
@@ -196,7 +196,7 @@ extension TerminalView: UITextViewDelegate {
 					
 					let output = processor.process(command: String(input))
 					if !output.isEmpty {
-						textView.text = textView.text + "\n\(output)"
+                        textView.text = textView.text + "\n\(output)"
 					}
 					
 				}

--- a/Terminal/View/TerminalView.swift
+++ b/Terminal/View/TerminalView.swift
@@ -168,7 +168,7 @@ extension TerminalView: UITextViewDelegate {
 	}
 	
 	func textView(_ textView: UITextView, shouldChangeTextIn range: NSRange, replacementText text: String) -> Bool {
-    
+		
 		let i = textView.text.distance(from: textView.text.startIndex, to: currentCommandStartIndex)
 		
 		if range.location < i {
@@ -196,7 +196,7 @@ extension TerminalView: UITextViewDelegate {
 					
 					let output = processor.process(command: String(input))
 					if !output.isEmpty {
-                         textView.text = textView.text + "\n\(output)"
+						textView.text = textView.text + "\n\(output)"
 					}
 					
 				}

--- a/Terminal/View/TerminalView.swift
+++ b/Terminal/View/TerminalView.swift
@@ -168,7 +168,7 @@ extension TerminalView: UITextViewDelegate {
 	}
 	
 	func textView(_ textView: UITextView, shouldChangeTextIn range: NSRange, replacementText text: String) -> Bool {
-        
+    
 		let i = textView.text.distance(from: textView.text.startIndex, to: currentCommandStartIndex)
 		
 		if range.location < i {
@@ -196,7 +196,7 @@ extension TerminalView: UITextViewDelegate {
 					
 					let output = processor.process(command: String(input))
 					if !output.isEmpty {
-                        textView.text = textView.text + "\n\(output)"
+                         textView.text = textView.text + "\n\(output)"
 					}
 					
 				}


### PR DESCRIPTION
A rather large PR. 
- parse all arguments to replace "~" with the value of $HOME, and environment variables with their values ($SHELL, $TMPDIR, ... other values defined by the user). Do not expand arguments between quotes. 
- added env, setenv, unsetenv to the list of commands (in ios_system)
- added cd to ios_system and removed it from Terminal/Controller/ViewController.swift. Users can now type "cd ~" or "cd $HOME" and end up in the expected place. "cd -" also works (back to previous directory). 
- added awk, sed to the list of commands in ios_system.
- added scp and sftp to the list of commands. This is done inside curl/src/tool_main.c by parsing the arguments, depending on the value of argv[0]. For scp to work, the users will have to copy their SSH keys from elsewhere, and place their passphrases in the .curlrc file (because there is no way to interact with the shell).
- more complete error messages for many shell commands. I thought I had committed these, but apparently not.
- ed is in the source, and compiled, but is not activated in ios_system, because it requires interaction. The idea is to be ready for when we have an interactive shell. 