### PR TITLE
Add ability to clear screen with keyboard shortcut

### DIFF
--- a/Terminal/Controller/ViewController.swift
+++ b/Terminal/Controller/ViewController.swift
@@ -244,13 +244,31 @@ class ViewController: UIViewController {
 
 	}
 	
-	override var keyCommands: [UIKeyCommand]? {
-		let prevCmd = UIKeyCommand(input: UIKeyInputUpArrow, modifierFlags: UIKeyModifierFlags(rawValue: 0), action: #selector(selectPreviousCommand))
-
-		let nextCmd = UIKeyCommand(input: UIKeyInputDownArrow, modifierFlags: UIKeyModifierFlags(rawValue: 0), action: #selector(selectNextCommand))
-
+	@objc func clearScreen() {
 		
-		return [prevCmd, nextCmd]
+		terminalView.clearScreen()
+		
+	}
+	
+	override var keyCommands: [UIKeyCommand]? {
+		
+		let prevCmd = UIKeyCommand(input: UIKeyInputUpArrow,
+								   modifierFlags: UIKeyModifierFlags(rawValue: 0),
+								   action: #selector(selectPreviousCommand),
+								   discoverabilityTitle: "Previous command")
+		
+		let nextCmd = UIKeyCommand(input: UIKeyInputDownArrow,
+								   modifierFlags: UIKeyModifierFlags(rawValue: 0),
+								   action: #selector(selectNextCommand),
+								   discoverabilityTitle: "Next command")
+		
+		let clearCmd = UIKeyCommand(input: "L",
+									modifierFlags: .control,
+									action: #selector(clearScreen),
+									discoverabilityTitle: "Clear screen")
+		
+		return [prevCmd, nextCmd, clearCmd]
+		
 	}
 	
 }

--- a/Terminal/View/TerminalView.swift
+++ b/Terminal/View/TerminalView.swift
@@ -108,6 +108,14 @@ class TerminalView: UIView {
 		
 	}
 	
+	func clearScreen() {
+		
+		currentCommandStartIndex = nil
+		textView.text = "\(deviceName): "
+		currentCommandStartIndex = textView.text.endIndex
+		
+	}
+	
 	@discardableResult
 	override func becomeFirstResponder() -> Bool {
 		return textView.becomeFirstResponder()
@@ -212,14 +220,6 @@ extension TerminalView: UITextViewDelegate {
 		print(text)
 		
 		return true
-	}
-	
-	func clearScreen() {
-		
-		currentCommandStartIndex = nil
-		textView.text = "\(deviceName): "
-		currentCommandStartIndex = textView.text.endIndex
-		
 	}
 	
 	func textViewDidChange(_ textView: UITextView) {

--- a/Terminal/View/TerminalView.swift
+++ b/Terminal/View/TerminalView.swift
@@ -187,9 +187,7 @@ extension TerminalView: UITextViewDelegate {
 
 				if input == "clear" {
 					
-					currentCommandStartIndex = nil
-					textView.text = "\(deviceName): "
-					currentCommandStartIndex = textView.text.endIndex
+					clearScreen()
 					return false
 					
 				} else {
@@ -214,6 +212,14 @@ extension TerminalView: UITextViewDelegate {
 		print(text)
 		
 		return true
+	}
+	
+	func clearScreen() {
+		
+		currentCommandStartIndex = nil
+		textView.text = "\(deviceName): "
+		currentCommandStartIndex = textView.text.endIndex
+		
 	}
 	
 	func textViewDidChange(_ textView: UITextView) {


### PR DESCRIPTION
Added ability to clear screen with `Ctrl + L` keyboard shortcut.

Also added `discoverabilityTitle` to all available keyboard shortcuts.

Note: This solution does not add clear command to the command history! Reason: the OS X Terminal allplication works the same way.

Fixes #17 

![img_0402](https://user-images.githubusercontent.com/869119/34908268-2e765712-f88d-11e7-8a59-e69f82483268.PNG)
