### PR TITLE
Add app's commands

### DIFF
--- a/OpenTerm.xcodeproj/project.pbxproj
+++ b/OpenTerm.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		3A9AABCA201A351B00B14D75 /* Command.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A9AABC8201A351A00B14D75 /* Command.swift */; };
+		3A9AABCB201A351B00B14D75 /* HelloWorld.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A9AABC9201A351B00B14D75 /* HelloWorld.swift */; };
 		5A38CC73C499E1A878353871 /* Pods_OpenTerm.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FC01604DAC695ABD64544260 /* Pods_OpenTerm.framework */; };
 		BE000C081FEC4F6C00D06B91 /* ios_system.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BE3768EE1FEC4DCE00D5A2D1 /* ios_system.framework */; settings = {ATTRIBUTES = (Required, ); }; };
 		BE000C091FEC4F6F00D06B91 /* ios_system.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BE3768EE1FEC4DCE00D5A2D1 /* ios_system.framework */; settings = {ATTRIBUTES = (Required, ); }; };
@@ -46,6 +48,8 @@
 
 /* Begin PBXFileReference section */
 		24F6A88F715402F565B82F26 /* Pods-Terminal.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Terminal.release.xcconfig"; path = "Pods/Target Support Files/Pods-Terminal/Pods-Terminal.release.xcconfig"; sourceTree = "<group>"; };
+		3A9AABC8201A351A00B14D75 /* Command.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Command.swift; sourceTree = "<group>"; };
+		3A9AABC9201A351B00B14D75 /* HelloWorld.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HelloWorld.swift; sourceTree = "<group>"; };
 		448CC7691FD84EB5D2C24705 /* Pods-OpenTerm.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-OpenTerm.debug.xcconfig"; path = "Pods/Target Support Files/Pods-OpenTerm/Pods-OpenTerm.debug.xcconfig"; sourceTree = "<group>"; };
 		83138AA9A57F46310B4DFF53 /* Pods_Terminal.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Terminal.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		BE165407201909030067EC92 /* xCallBackUrl.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = xCallBackUrl.swift; sourceTree = "<group>"; };
@@ -88,6 +92,15 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		3A9AABC7201A34F700B14D75 /* Commands */ = {
+			isa = PBXGroup;
+			children = (
+				3A9AABC8201A351A00B14D75 /* Command.swift */,
+				3A9AABC9201A351B00B14D75 /* HelloWorld.swift */,
+			);
+			path = Commands;
+			sourceTree = "<group>";
+		};
 		BE3768EC1FEC4DCE00D5A2D1 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
@@ -119,6 +132,7 @@
 		BE3808541FD9BFB600393EB8 /* OpenTerm */ = {
 			isa = PBXGroup;
 			children = (
+				3A9AABC7201A34F700B14D75 /* Commands */,
 				BEA8E28F2001346D00002475 /* Util */,
 				BEA8E28E2001345700002475 /* View */,
 				BEA8E28D2001344400002475 /* Controller */,
@@ -326,7 +340,9 @@
 				BEA499261FD9C4D7001B9B9D /* DocumentManager.swift in Sources */,
 				BEECFF0A1FFC1DC0009608B3 /* HistoryViewController.swift in Sources */,
 				BEA4992E1FDC305B001B9B9D /* KeyboardObserver.swift in Sources */,
+				3A9AABCB201A351B00B14D75 /* HelloWorld.swift in Sources */,
 				F4602B41200A08D0009D0547 /* ColorPickerViewController.swift in Sources */,
+				3A9AABCA201A351B00B14D75 /* Command.swift in Sources */,
 				BE9275062013961D00BD2761 /* UserDefaultsController.swift in Sources */,
 				BE3808561FD9BFB600393EB8 /* AppDelegate.swift in Sources */,
 			);
@@ -469,12 +485,12 @@
 				CODE_SIGN_ENTITLEMENTS = OpenTerm/OpenTerm.entitlements;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
-                DEVELOPMENT_TEAM = 6G5LMQ72D8;
+				DEVELOPMENT_TEAM = 6G5LMQ72D8;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = "$(SRCROOT)/OpenTerm/Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-                PRODUCT_BUNDLE_IDENTIFIER = com.silverfox.Terminal;
+				PRODUCT_BUNDLE_IDENTIFIER = com.silverfox.Terminal;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_VERSION = 4.0;
@@ -490,12 +506,12 @@
 				CODE_SIGN_ENTITLEMENTS = OpenTerm/OpenTerm.entitlements;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
-                DEVELOPMENT_TEAM = 6G5LMQ72D8;
+				DEVELOPMENT_TEAM = 6G5LMQ72D8;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = "$(SRCROOT)/OpenTerm/Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-                PRODUCT_BUNDLE_IDENTIFIER = com.silverfox.Terminal;
+				PRODUCT_BUNDLE_IDENTIFIER = com.silverfox.Terminal;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_VERSION = 4.0;

--- a/OpenTerm/Commands/Command.swift
+++ b/OpenTerm/Commands/Command.swift
@@ -1,0 +1,48 @@
+//
+//  Command.swift
+//  OpenTerm
+//
+//  Created by Adrian Labbé on 24.01.18.
+//  Copyright © 2018 Silver Fox. All rights reserved.
+//
+
+import UIKit
+
+/// Class template for writing a command.
+class Command {
+    
+    /// All commands per name.
+    static let allAppCommands: [String:Command] = ["helloworld":HelloWorld()]
+    
+    /// Text view where print text.
+    static var textView: UITextView?
+    
+    /// Print to `textView`.
+    ///
+    /// - Parameters:
+    ///     - text: Text to add to the textView.
+    func printtv(_ item: Any) {
+        guard let textView = Command.textView else { return }
+        textView.text = textView.text+"\(item)"
+    }
+    
+    /// Print to `textView` with a newline.
+    ///
+    /// - Parameters:
+    ///     - text: Text to add to the textView.
+    func printlntv(_ item: Any) {
+        printtv("\(item)\n")
+    }
+    
+    /// Subclass and put code here.
+    ///
+    /// Call super's function to put a newline at start.
+    /// - Parameters:
+    ///     - arguments: Arguments sent.
+    /// - Returns: Return code.
+    func execute(withArguments arguments: [String]) -> Int {
+        printtv("\n")
+        
+        return 0
+    }
+}

--- a/OpenTerm/Commands/HelloWorld.swift
+++ b/OpenTerm/Commands/HelloWorld.swift
@@ -1,0 +1,37 @@
+//
+//  HelloWorld.swift
+//  OpenTerm
+//
+//  Created by Adrian Labbé on 24.01.18.
+//  Copyright © 2018 Silver Fox. All rights reserved.
+//
+
+import Foundation
+
+/// Test builtin command.
+class HelloWorld: Command {
+    
+    /// Prints Hello World!.
+    override func execute(withArguments arguments: [String]) -> Int {
+        
+        _ = super.execute(withArguments: arguments)
+        
+        if arguments.contains("--argv") || arguments.contains("-argv") || arguments.contains("-a") {
+            // Print given arguments
+            printlntv(arguments)
+            return 0
+        } else if arguments.contains("--help") || arguments.contains("-help") || arguments.contains("-h") {
+            printtv("Prints Hello World!\n\n--argv, -a: Print arguments")
+        } else if arguments.count > 0 {
+            printlntv("Invalid arguments!")
+            return 1
+        }
+            
+        printlntv("Hello World!")
+            
+        return 0
+            
+        
+    }
+    
+}

--- a/OpenTerm/Controller/ViewController.swift
+++ b/OpenTerm/Controller/ViewController.swift
@@ -50,6 +50,8 @@ class ViewController: UIViewController {
 		terminalView.processor = self
 		terminalView.delegate = self
 		
+        Command.textView = terminalView.textView
+        
 		updateTitle()
 		setStdOut()
 		setStdErr()
@@ -381,6 +383,19 @@ extension ViewController: TerminalProcessor {
             completion(availableCommands().joined(separator: ", "))
 			return
 		}
+        
+        // Builtin command
+        let executable = command.components(separatedBy: " ")[0]
+        if Command.allAppCommands.keys.contains(executable) {
+            
+            var arguments = command.components(separatedBy: " ")
+            arguments.remove(at: 0)
+            
+            _ = Command.allAppCommands[executable]?.execute(withArguments: arguments)
+            
+            completion("")
+            return
+        }
 
         setStdOut()
         setStdErr()


### PR DESCRIPTION
I added a class `Command` to code custom commands for app.
The `helloworld` command is an example.

To create a command, create a subclass of `Command` like this:

```swift
class CommandClass: Command {
    
    override func execute(withArguments arguments: [String]) -> Int {
        
        _ = super.execute(withArguments: arguments) // Call it to add a newline at start

        // Put code here
        // Use printtv(_:) or printlntv(_:) to print to the Text view

        // Return code
        return 0
    }
    
}
```

And then add the command to the `Command`static `allAppCommands` like this:

```swift
"commandname":CommandClass()
```

After that, if you type `commandname` and the `CommandClass`'s `execute(withArguments :) ` function will be called with given arguments.