### PR TITLE
Scripting support

### DIFF
--- a/OpenTerm.xcodeproj/project.pbxproj
+++ b/OpenTerm.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		3CA32102201FF6B100974B5F /* Script.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CA32101201FF6B100974B5F /* Script.swift */; };
 		3CA32105201FFC1300974B5F /* ScriptEditViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CA32104201FFC1300974B5F /* ScriptEditViewController.swift */; };
 		3CA3210920211D5600974B5F /* ScriptExecutorCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CA3210820211D5600974B5F /* ScriptExecutorCommand.swift */; };
+		3CA3210B20212D4200974B5F /* CommandExecutionContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CA3210A20212D4200974B5F /* CommandExecutionContext.swift */; };
 		5A38CC73C499E1A878353871 /* Pods_OpenTerm.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FC01604DAC695ABD64544260 /* Pods_OpenTerm.framework */; };
 		BE000C081FEC4F6C00D06B91 /* ios_system.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BE3768EE1FEC4DCE00D5A2D1 /* ios_system.framework */; settings = {ATTRIBUTES = (Required, ); }; };
 		BE000C091FEC4F6F00D06B91 /* ios_system.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BE3768EE1FEC4DCE00D5A2D1 /* ios_system.framework */; settings = {ATTRIBUTES = (Required, ); }; };
@@ -66,6 +67,7 @@
 		3CA32101201FF6B100974B5F /* Script.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Script.swift; sourceTree = "<group>"; };
 		3CA32104201FFC1300974B5F /* ScriptEditViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScriptEditViewController.swift; sourceTree = "<group>"; };
 		3CA3210820211D5600974B5F /* ScriptExecutorCommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScriptExecutorCommand.swift; sourceTree = "<group>"; };
+		3CA3210A20212D4200974B5F /* CommandExecutionContext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommandExecutionContext.swift; sourceTree = "<group>"; };
 		448CC7691FD84EB5D2C24705 /* Pods-OpenTerm.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-OpenTerm.debug.xcconfig"; path = "Pods/Target Support Files/Pods-OpenTerm/Pods-OpenTerm.debug.xcconfig"; sourceTree = "<group>"; };
 		83138AA9A57F46310B4DFF53 /* Pods_Terminal.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Terminal.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		BE165407201909030067EC92 /* xCallBackUrl.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = xCallBackUrl.swift; sourceTree = "<group>"; };
@@ -114,6 +116,7 @@
 			isa = PBXGroup;
 			children = (
 				3C406E1920207CE7005F97C4 /* CommandExecutor.swift */,
+				3CA3210A20212D4200974B5F /* CommandExecutionContext.swift */,
 			);
 			path = Execution;
 			sourceTree = "<group>";
@@ -409,6 +412,7 @@
 				BE505066201E5ED900CDFC60 /* Share.swift in Sources */,
 				BEECFF0A1FFC1DC0009608B3 /* HistoryViewController.swift in Sources */,
 				BEA4992E1FDC305B001B9B9D /* KeyboardObserver.swift in Sources */,
+				3CA3210B20212D4200974B5F /* CommandExecutionContext.swift in Sources */,
 				3CA320FD201FE73900974B5F /* TerminalTextView.swift in Sources */,
 				F4602B41200A08D0009D0547 /* ColorPickerViewController.swift in Sources */,
 				BE9275062013961D00BD2761 /* UserDefaultsController.swift in Sources */,

--- a/OpenTerm.xcodeproj/project.pbxproj
+++ b/OpenTerm.xcodeproj/project.pbxproj
@@ -169,6 +169,7 @@
 				EDE154E4BB3A66786AACAA5C /* Pods */,
 			);
 			sourceTree = "<group>";
+			usesTabs = 0;
 		};
 		BE3808531FD9BFB600393EB8 /* Products */ = {
 			isa = PBXGroup;

--- a/OpenTerm.xcodeproj/project.pbxproj
+++ b/OpenTerm.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		3CA320FF201FE8E100974B5F /* ScriptsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CA320FE201FE8E100974B5F /* ScriptsViewController.swift */; };
 		3CA32102201FF6B100974B5F /* Script.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CA32101201FF6B100974B5F /* Script.swift */; };
 		3CA32105201FFC1300974B5F /* ScriptEditViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CA32104201FFC1300974B5F /* ScriptEditViewController.swift */; };
+		3CA3210920211D5600974B5F /* ScriptExecutorCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CA3210820211D5600974B5F /* ScriptExecutorCommand.swift */; };
 		5A38CC73C499E1A878353871 /* Pods_OpenTerm.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FC01604DAC695ABD64544260 /* Pods_OpenTerm.framework */; };
 		BE000C081FEC4F6C00D06B91 /* ios_system.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BE3768EE1FEC4DCE00D5A2D1 /* ios_system.framework */; settings = {ATTRIBUTES = (Required, ); }; };
 		BE000C091FEC4F6F00D06B91 /* ios_system.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BE3768EE1FEC4DCE00D5A2D1 /* ios_system.framework */; settings = {ATTRIBUTES = (Required, ); }; };
@@ -64,6 +65,7 @@
 		3CA320FE201FE8E100974B5F /* ScriptsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScriptsViewController.swift; sourceTree = "<group>"; };
 		3CA32101201FF6B100974B5F /* Script.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Script.swift; sourceTree = "<group>"; };
 		3CA32104201FFC1300974B5F /* ScriptEditViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScriptEditViewController.swift; sourceTree = "<group>"; };
+		3CA3210820211D5600974B5F /* ScriptExecutorCommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScriptExecutorCommand.swift; sourceTree = "<group>"; };
 		448CC7691FD84EB5D2C24705 /* Pods-OpenTerm.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-OpenTerm.debug.xcconfig"; path = "Pods/Target Support Files/Pods-OpenTerm/Pods-OpenTerm.debug.xcconfig"; sourceTree = "<group>"; };
 		83138AA9A57F46310B4DFF53 /* Pods_Terminal.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Terminal.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		BE165407201909030067EC92 /* xCallBackUrl.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = xCallBackUrl.swift; sourceTree = "<group>"; };
@@ -129,6 +131,7 @@
 			isa = PBXGroup;
 			children = (
 				3CA32101201FF6B100974B5F /* Script.swift */,
+				3CA3210820211D5600974B5F /* ScriptExecutorCommand.swift */,
 			);
 			path = Scripting;
 			sourceTree = "<group>";
@@ -409,6 +412,7 @@
 				3CA320FD201FE73900974B5F /* TerminalTextView.swift in Sources */,
 				F4602B41200A08D0009D0547 /* ColorPickerViewController.swift in Sources */,
 				BE9275062013961D00BD2761 /* UserDefaultsController.swift in Sources */,
+				3CA3210920211D5600974B5F /* ScriptExecutorCommand.swift in Sources */,
 				3C406E1D2020988B005F97C4 /* AutoCompleteManager+InputAssistant.swift in Sources */,
 				BE3808561FD9BFB600393EB8 /* AppDelegate.swift in Sources */,
 				3C406E1A20207CE7005F97C4 /* CommandExecutor.swift in Sources */,

--- a/OpenTerm.xcodeproj/project.pbxproj
+++ b/OpenTerm.xcodeproj/project.pbxproj
@@ -9,6 +9,12 @@
 /* Begin PBXBuildFile section */
 		3C2E4374201EF67C00E4254A /* TerminalView+AutoComplete.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C2E4373201EF67C00E4254A /* TerminalView+AutoComplete.swift */; };
 		3C2E4385201EFF4700E4254A /* AutoCompleteManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C2E4384201EFF4700E4254A /* AutoCompleteManager.swift */; };
+		3C406E1A20207CE7005F97C4 /* CommandExecutor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C406E1920207CE7005F97C4 /* CommandExecutor.swift */; };
+		3C406E1D2020988B005F97C4 /* AutoCompleteManager+InputAssistant.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C406E1C2020988B005F97C4 /* AutoCompleteManager+InputAssistant.swift */; };
+		3CA320FD201FE73900974B5F /* TerminalTextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CA320FC201FE73900974B5F /* TerminalTextView.swift */; };
+		3CA320FF201FE8E100974B5F /* ScriptsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CA320FE201FE8E100974B5F /* ScriptsViewController.swift */; };
+		3CA32102201FF6B100974B5F /* Script.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CA32101201FF6B100974B5F /* Script.swift */; };
+		3CA32105201FFC1300974B5F /* ScriptEditViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CA32104201FFC1300974B5F /* ScriptEditViewController.swift */; };
 		5A38CC73C499E1A878353871 /* Pods_OpenTerm.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FC01604DAC695ABD64544260 /* Pods_OpenTerm.framework */; };
 		BE000C081FEC4F6C00D06B91 /* ios_system.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BE3768EE1FEC4DCE00D5A2D1 /* ios_system.framework */; settings = {ATTRIBUTES = (Required, ); }; };
 		BE000C091FEC4F6F00D06B91 /* ios_system.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BE3768EE1FEC4DCE00D5A2D1 /* ios_system.framework */; settings = {ATTRIBUTES = (Required, ); }; };
@@ -52,6 +58,12 @@
 		24F6A88F715402F565B82F26 /* Pods-Terminal.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Terminal.release.xcconfig"; path = "Pods/Target Support Files/Pods-Terminal/Pods-Terminal.release.xcconfig"; sourceTree = "<group>"; };
 		3C2E4373201EF67C00E4254A /* TerminalView+AutoComplete.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TerminalView+AutoComplete.swift"; sourceTree = "<group>"; };
 		3C2E4384201EFF4700E4254A /* AutoCompleteManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoCompleteManager.swift; sourceTree = "<group>"; };
+		3C406E1920207CE7005F97C4 /* CommandExecutor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommandExecutor.swift; sourceTree = "<group>"; };
+		3C406E1C2020988B005F97C4 /* AutoCompleteManager+InputAssistant.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AutoCompleteManager+InputAssistant.swift"; sourceTree = "<group>"; };
+		3CA320FC201FE73900974B5F /* TerminalTextView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalTextView.swift; sourceTree = "<group>"; };
+		3CA320FE201FE8E100974B5F /* ScriptsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScriptsViewController.swift; sourceTree = "<group>"; };
+		3CA32101201FF6B100974B5F /* Script.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Script.swift; sourceTree = "<group>"; };
+		3CA32104201FFC1300974B5F /* ScriptEditViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScriptEditViewController.swift; sourceTree = "<group>"; };
 		448CC7691FD84EB5D2C24705 /* Pods-OpenTerm.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-OpenTerm.debug.xcconfig"; path = "Pods/Target Support Files/Pods-OpenTerm/Pods-OpenTerm.debug.xcconfig"; sourceTree = "<group>"; };
 		83138AA9A57F46310B4DFF53 /* Pods_Terminal.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Terminal.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		BE165407201909030067EC92 /* xCallBackUrl.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = xCallBackUrl.swift; sourceTree = "<group>"; };
@@ -96,6 +108,40 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		3C406E1820207CDA005F97C4 /* Execution */ = {
+			isa = PBXGroup;
+			children = (
+				3C406E1920207CE7005F97C4 /* CommandExecutor.swift */,
+			);
+			path = Execution;
+			sourceTree = "<group>";
+		};
+		3C406E1B2020987B005F97C4 /* AutoComplete */ = {
+			isa = PBXGroup;
+			children = (
+				3C2E4384201EFF4700E4254A /* AutoCompleteManager.swift */,
+				3C406E1C2020988B005F97C4 /* AutoCompleteManager+InputAssistant.swift */,
+			);
+			path = AutoComplete;
+			sourceTree = "<group>";
+		};
+		3CA32100201FF6A100974B5F /* Scripting */ = {
+			isa = PBXGroup;
+			children = (
+				3CA32101201FF6B100974B5F /* Script.swift */,
+			);
+			path = Scripting;
+			sourceTree = "<group>";
+		};
+		3CA32103201FFC0300974B5F /* Scripting */ = {
+			isa = PBXGroup;
+			children = (
+				3CA320FE201FE8E100974B5F /* ScriptsViewController.swift */,
+				3CA32104201FFC1300974B5F /* ScriptEditViewController.swift */,
+			);
+			path = Scripting;
+			sourceTree = "<group>";
+		};
 		BE244DC6201FBB4F00A7EA4E /* Default certs */ = {
 			isa = PBXGroup;
 			children = (
@@ -153,6 +199,7 @@
 		BEA8E28D2001344400002475 /* Controller */ = {
 			isa = PBXGroup;
 			children = (
+				3CA32103201FFC0300974B5F /* Scripting */,
 				BE3808571FD9BFB600393EB8 /* ViewController.swift */,
 				BEECFF091FFC1DC0009608B3 /* HistoryViewController.swift */,
 				BEECFF381FFEC187009608B3 /* SettingsViewController.swift */,
@@ -167,6 +214,7 @@
 				BEA4992F1FDC3B93001B9B9D /* TerminalView.swift */,
 				3C2E4373201EF67C00E4254A /* TerminalView+AutoComplete.swift */,
 				F456629D200B9BC500C574AA /* ColorDisplayView.swift */,
+				3CA320FC201FE73900974B5F /* TerminalTextView.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -174,6 +222,9 @@
 		BEA8E28F2001346D00002475 /* Util */ = {
 			isa = PBXGroup;
 			children = (
+				3C406E1B2020987B005F97C4 /* AutoComplete */,
+				3C406E1820207CDA005F97C4 /* Execution */,
+				3CA32100201FF6A100974B5F /* Scripting */,
 				BEA8E2902001348C00002475 /* UIColor+AssetCatalog.swift */,
 				F4602B48200A63FC009D0547 /* UserDefaults+UIColor.swift */,
 				BEA4992D1FDC305B001B9B9D /* KeyboardObserver.swift */,
@@ -181,7 +232,6 @@
 				BE505065201E5ED900CDFC60 /* Share.swift */,
 				BE9275052013961D00BD2761 /* UserDefaultsController.swift */,
 				BE165407201909030067EC92 /* xCallBackUrl.swift */,
-				3C2E4384201EFF4700E4254A /* AutoCompleteManager.swift */,
 			);
 			path = Util;
 			sourceTree = "<group>";
@@ -340,10 +390,13 @@
 			buildActionMask = 2147483647;
 			files = (
 				BEA8E2912001348C00002475 /* UIColor+AssetCatalog.swift in Sources */,
+				3CA320FF201FE8E100974B5F /* ScriptsViewController.swift in Sources */,
 				3C2E4385201EFF4700E4254A /* AutoCompleteManager.swift in Sources */,
+				3CA32102201FF6B100974B5F /* Script.swift in Sources */,
 				BEA499301FDC3B93001B9B9D /* TerminalView.swift in Sources */,
 				F4602B49200A63FC009D0547 /* UserDefaults+UIColor.swift in Sources */,
 				BE3808581FD9BFB600393EB8 /* ViewController.swift in Sources */,
+				3CA32105201FFC1300974B5F /* ScriptEditViewController.swift in Sources */,
 				3C2E4374201EF67C00E4254A /* TerminalView+AutoComplete.swift in Sources */,
 				BEECFF391FFEC187009608B3 /* SettingsViewController.swift in Sources */,
 				F456629E200B9BC500C574AA /* ColorDisplayView.swift in Sources */,
@@ -352,9 +405,12 @@
 				BE505066201E5ED900CDFC60 /* Share.swift in Sources */,
 				BEECFF0A1FFC1DC0009608B3 /* HistoryViewController.swift in Sources */,
 				BEA4992E1FDC305B001B9B9D /* KeyboardObserver.swift in Sources */,
+				3CA320FD201FE73900974B5F /* TerminalTextView.swift in Sources */,
 				F4602B41200A08D0009D0547 /* ColorPickerViewController.swift in Sources */,
 				BE9275062013961D00BD2761 /* UserDefaultsController.swift in Sources */,
+				3C406E1D2020988B005F97C4 /* AutoCompleteManager+InputAssistant.swift in Sources */,
 				BE3808561FD9BFB600393EB8 /* AppDelegate.swift in Sources */,
+				3C406E1A20207CE7005F97C4 /* CommandExecutor.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/OpenTerm/Base.lproj/Main.storyboard
+++ b/OpenTerm/Base.lproj/Main.storyboard
@@ -64,6 +64,11 @@
                                     <action selector="openFolder:" destination="BYZ-38-t0r" id="zGA-4q-tGD"/>
                                 </connections>
                             </barButtonItem>
+                            <barButtonItem systemItem="compose" id="8oj-SI-eX7">
+                                <connections>
+                                    <action selector="showScripts:" destination="BYZ-38-t0r" id="ui6-0d-Vo6"/>
+                                </connections>
+                            </barButtonItem>
                         </rightBarButtonItems>
                     </navigationItem>
                     <simulatedNavigationBarMetrics key="simulatedTopBarMetrics" barStyle="black" prompted="NO"/>
@@ -521,6 +526,47 @@ This project uses the open source ios_system project by Nicolas Holzschuch. This
                 <placeholder placeholderIdentifier="IBFirstResponder" id="0lK-jA-c4A" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="479" y="909"/>
+        </scene>
+        <!--Scripts-->
+        <scene sceneID="Lu9-3r-2Ro">
+            <objects>
+                <tableViewController storyboardIdentifier="ScriptsViewController" id="9AK-0c-p31" customClass="ScriptsViewController" customModule="OpenTerm" customModuleProvider="target" sceneMemberID="viewController">
+                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" id="bin-oB-viz">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" name="Panel Background Color"/>
+                        <color key="separatorColor" white="0.16213727680000001" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                        <prototypes>
+                            <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" reuseIdentifier="ScriptCell" textLabel="3Fb-vg-hd2" style="IBUITableViewCellStyleDefault" id="lCg-Nk-zL3">
+                                <rect key="frame" x="0.0" y="28" width="375" height="44"/>
+                                <autoresizingMask key="autoresizingMask"/>
+                                <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="lCg-Nk-zL3" id="eek-jL-6Hu">
+                                    <rect key="frame" x="0.0" y="0.0" width="341" height="43.5"/>
+                                    <autoresizingMask key="autoresizingMask"/>
+                                    <subviews>
+                                        <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Title" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="3Fb-vg-hd2">
+                                            <rect key="frame" x="16" y="0.0" width="324" height="43.5"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                            <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                            <nil key="highlightedColor"/>
+                                        </label>
+                                    </subviews>
+                                </tableViewCellContentView>
+                                <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                            </tableViewCell>
+                        </prototypes>
+                        <connections>
+                            <outlet property="dataSource" destination="9AK-0c-p31" id="tPJ-22-kKT"/>
+                            <outlet property="delegate" destination="9AK-0c-p31" id="mXk-8q-jlF"/>
+                        </connections>
+                    </tableView>
+                    <navigationItem key="navigationItem" title="Scripts" id="qUx-6l-a2N"/>
+                    <simulatedNavigationBarMetrics key="simulatedTopBarMetrics" barStyle="black" prompted="NO"/>
+                </tableViewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="Xoy-Rx-17A" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="2337" y="134"/>
         </scene>
     </scenes>
     <resources>

--- a/OpenTerm/Controller/HistoryViewController.swift
+++ b/OpenTerm/Controller/HistoryViewController.swift
@@ -30,6 +30,9 @@ class HistoryViewController: UIViewController {
 		self.view.tintColor = .defaultMainTintColor
 		self.navigationController?.navigationBar.barStyle = .blackTranslucent
 
+		// Remove separators beyond content
+		self.tableView.tableFooterView = UIView()
+
 		tableView.dataSource = self
 		tableView.delegate = self
 

--- a/OpenTerm/Controller/Scripting/ScriptEditViewController.swift
+++ b/OpenTerm/Controller/Scripting/ScriptEditViewController.swift
@@ -81,7 +81,7 @@ extension ScriptEditViewController: AutoCompleteManagerDataSource {
         return ["+ new argument"] + self.script.argumentNames
     }
 
-    func optionsForCommand(_ command: String) -> [String] {
+    func completionsForCommand(_ command: String) -> [AutoCompleteManager.Completion] {
         return []
     }
 }
@@ -90,10 +90,10 @@ extension ScriptEditViewController: InputAssistantViewDelegate {
     func inputAssistantView(_ inputAssistantView: InputAssistantView, didSelectSuggestionAtIndex index: Int) {
         let suggestion = autoCompleteManager.completions[index]
 
-        if suggestion == "+ new argument" {
+        if suggestion.name == "+ new argument" {
             textView.insertText("$<<argument>>")
         } else {
-            textView.insertText("$<<\(suggestion)>>")
+            textView.insertText("$<<\(suggestion.name)>>")
         }
     }
 }

--- a/OpenTerm/Controller/Scripting/ScriptEditViewController.swift
+++ b/OpenTerm/Controller/Scripting/ScriptEditViewController.swift
@@ -1,0 +1,99 @@
+//
+//  ScriptEditViewController.swift
+//  OpenTerm
+//
+//  Created by iamcdowe on 1/29/18.
+//  Copyright © 2018 Silver Fox. All rights reserved.
+//
+
+import UIKit
+import InputAssistant
+
+class ScriptEditViewController: UIViewController {
+
+	var script: Script
+    let textView: TerminalTextView
+    let autoCompleteManager: AutoCompleteManager
+    let inputAssistantView: InputAssistantView
+
+	init(script: Script) {
+		self.script = script
+        self.textView = TerminalTextView()
+        self.autoCompleteManager = AutoCompleteManager()
+        self.inputAssistantView = InputAssistantView()
+		super.init(nibName: nil, bundle: nil)
+		self.title = script.name
+	}
+
+	required init?(coder aDecoder: NSCoder) { fatalError("init(coder:) has not been implemented") }
+
+	override func loadView() {
+		view = textView
+	}
+
+	override func viewDidLoad() {
+		super.viewDidLoad()
+
+		textView.delegate = self
+
+        // Set up auto complete manager
+        self.autoCompleteManager.delegate = self.inputAssistantView
+        self.autoCompleteManager.dataSource = self
+
+        // Set up input assistant and text view for auto completion
+        self.inputAssistantView.delegate = self
+        self.inputAssistantView.dataSource = self.autoCompleteManager
+        self.textView.inputAccessoryView = self.inputAssistantView
+        self.inputAssistantView.tintColor = .lightGray
+
+        // Hide default undo/redo/etc buttons
+        textView.inputAssistantItem.leadingBarButtonGroups = []
+        textView.inputAssistantItem.trailingBarButtonGroups = []
+
+        // Disable built-in autocomplete
+        textView.autocorrectionType = .no
+	}
+
+	override func viewDidAppear(_ animated: Bool) {
+		super.viewDidAppear(animated)
+
+		textView.becomeFirstResponder()
+        textView.text = script.value
+	}
+    
+	private func save() {
+        // Save to disk
+		script.value = textView.text
+	}
+
+}
+
+extension ScriptEditViewController: UITextViewDelegate {
+
+    func textViewDidChange(_ textView: UITextView) {
+        save()
+        autoCompleteManager.reloadData()
+    }
+}
+
+extension ScriptEditViewController: AutoCompleteManagerDataSource {
+    func allCommandsForAutoCompletion() -> [String] {
+        return ["+ new argument"] + self.script.argumentNames
+    }
+
+    func optionsForCommand(_ command: String) -> [String] {
+        return []
+    }
+}
+
+extension ScriptEditViewController: InputAssistantViewDelegate {
+    func inputAssistantView(_ inputAssistantView: InputAssistantView, didSelectSuggestionAtIndex index: Int) {
+        let suggestion = autoCompleteManager.completions[index]
+
+        if suggestion == "+ new argument" {
+            textView.insertText("$<<argument>>")
+        } else {
+            textView.insertText("$<<\(suggestion)>>")
+        }
+    }
+}

--- a/OpenTerm/Controller/Scripting/ScriptsViewController.swift
+++ b/OpenTerm/Controller/Scripting/ScriptsViewController.swift
@@ -1,0 +1,107 @@
+//
+//  ScriptsViewController.swift
+//  OpenTerm
+//
+//  Created by iamcdowe on 1/29/18.
+//  Copyright © 2018 Silver Fox. All rights reserved.
+//
+
+import UIKit
+import PanelKit
+
+class ScriptsViewController: UITableViewController {
+
+	var scriptNames: [String] = [] {
+		didSet { tableView.reloadData() }
+	}
+
+	override func viewDidLoad() {
+		super.viewDidLoad()
+
+		self.view.tintColor = .defaultMainTintColor
+		self.navigationController?.navigationBar.barStyle = .blackTranslucent
+
+		// Remove separators beyond content
+		self.tableView.tableFooterView = UIView()
+	}
+
+	override func viewWillAppear(_ animated: Bool) {
+		super.viewWillAppear(animated)
+
+		reload()
+	}
+
+	@objc
+	fileprivate func addScript() {
+		let alertController = UIAlertController(title: "New Script", message: "Enter the name of your new script. Must be unique.", preferredStyle: .alert)
+        alertController.addTextField { textField in
+            textField.placeholder = "script_name"
+            textField.autocapitalizationType = .none
+            textField.autocorrectionType = .no
+        }
+        alertController.addAction(UIAlertAction.init(title: "Cancel", style: .cancel, handler: nil))
+        alertController.addAction(UIAlertAction.init(title: "Create", style: .default, handler: { [unowned self] _ in
+            guard let name = alertController.textFields?.first?.text else { return }
+            Script.create(name)
+            self.reload()
+        }))
+        self.present(alertController, animated: true, completion: nil)
+	}
+
+	private func reload() {
+		self.scriptNames = Script.allNames
+	}
+}
+
+extension ScriptsViewController {
+	override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+		return scriptNames.count
+	}
+
+	override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+		let cell = tableView.dequeueReusableCell(withIdentifier: "ScriptCell", for: indexPath)
+
+		cell.textLabel?.text = scriptNames[indexPath.row]
+
+		return cell
+	}
+}
+extension ScriptsViewController {
+	override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+		tableView.deselectRow(at: indexPath, animated: true)
+
+		guard let script = try? Script.named(scriptNames[indexPath.row]) else {
+			return
+		}
+		let vc = ScriptEditViewController(script: script)
+		self.navigationController?.pushViewController(vc, animated: true)
+	}
+}
+
+extension ScriptsViewController: PanelContentDelegate {
+
+	var rightBarButtonItems: [UIBarButtonItem] {
+		return [UIBarButtonItem.init(barButtonSystemItem: .add, target: self, action: #selector(addScript))]
+	}
+
+	var preferredPanelContentSize: CGSize {
+		return CGSize(width: 320, height: 480)
+	}
+
+	var minimumPanelContentSize: CGSize {
+		return CGSize(width: 320, height: 320)
+	}
+
+	var maximumPanelContentSize: CGSize {
+		return CGSize(width: 600, height: 800)
+	}
+
+}
+
+extension ScriptsViewController: PanelStateCoder {
+
+	var panelId: Int {
+		return 2
+	}
+
+}

--- a/OpenTerm/Controller/ViewController.swift
+++ b/OpenTerm/Controller/ViewController.swift
@@ -371,12 +371,6 @@ extension ViewController: TerminalViewDelegate {
         // Trim leading/trailing space
         let command = command.trimmingCharacters(in: .whitespacesAndNewlines)
 
-        // Separate in to command and arguments
-        let components = command.components(separatedBy: .whitespaces)
-        guard components.count > 0 else { return }
-        let program = components[0]
-        let args = Array(components[1..<components.endIndex])
-
         // Special case for clear
         if command == "clear" {
             terminalView.clearScreen()
@@ -391,21 +385,8 @@ extension ViewController: TerminalViewDelegate {
             terminalView.writePrompt()
             return
         }
-
-        // Special case for scripts
-        if Script.allNames.contains(program), let script = try? Script.named(program) {
-            // A script resolves to an array of commands to run. Dispatch each of those.
-            do {
-                let commands = try script.runnableCommands(withArgs: args)
-                executor.dispatch(commands)
-            } catch {
-                terminalView.writeOutput(error.localizedDescription)
-                terminalView.writePrompt()
-            }
-            return
-        }
-
-        // Default case: Dispatch the command to the executor
+        
+        // Dispatch the command to the executor
         executor.dispatch(command)
     }
 

--- a/OpenTerm/Controller/ViewController.swift
+++ b/OpenTerm/Controller/ViewController.swift
@@ -39,6 +39,11 @@ class ViewController: UIViewController {
 	var historyViewController: HistoryViewController!
 	var historyPanelViewController: PanelViewController!
 
+	var scriptsViewController: ScriptsViewController!
+	var scriptsPanelViewController: PanelViewController!
+
+    let executor = CommandExecutor()
+
 	override func viewDidLoad() {
 		super.viewDidLoad()
 
@@ -48,12 +53,14 @@ class ViewController: UIViewController {
 
 		historyPanelViewController = PanelViewController(with: historyViewController, in: self)
 
-		terminalView.processor = self
+		scriptsViewController = storyboard.instantiateViewController(withIdentifier: "ScriptsViewController") as! ScriptsViewController
+		scriptsPanelViewController = PanelViewController(with: scriptsViewController, in: self)
+
+        executor.delegate = self
+
 		terminalView.delegate = self
 
 		updateTitle()
-		setStdOut()
-		setStdErr()
 
 		NotificationCenter.default.addObserver(self, selector: #selector(didDismissKeyboard), name: .UIKeyboardDidHide, object: nil)
 
@@ -192,6 +199,16 @@ class ViewController: UIViewController {
 
 	}
 
+	@IBAction func showScripts(_ sender: UIBarButtonItem) {
+
+		scriptsPanelViewController.modalPresentationStyle = .popover
+		scriptsPanelViewController.popoverPresentationController?.barButtonItem = sender
+
+		scriptsPanelViewController.popoverPresentationController?.backgroundColor = scriptsViewController.view.backgroundColor
+		present(scriptsPanelViewController, animated: true, completion: nil)
+
+	}
+
 	func availableCommands() -> [String] {
 
         let commands = String(commandsAsString())
@@ -221,49 +238,6 @@ class ViewController: UIViewController {
 
 		print(availableCommands().joined(separator: "\n"))
 
-	}
-
-	func setStdOut() {
-
-		let fileManager = DocumentManager.shared.fileManager
-		let filePath = NSTemporaryDirectory().appending("out.txt")
-
-		try? fileManager.removeItem(atPath: filePath)
-
-		if !fileManager.fileExists(atPath: filePath) {
-			fileManager.createFile(atPath: filePath, contents: nil, attributes: nil)
-		}
-
-		freopen(filePath.toCString(), "a+", stdout)
-
-	}
-
-	func setStdErr() {
-
-		let fileManager = DocumentManager.shared.fileManager
-		let filePath = NSTemporaryDirectory().appending("err.txt")
-
-		try? fileManager.removeItem(atPath: filePath)
-
-		if !fileManager.fileExists(atPath: filePath) {
-			fileManager.createFile(atPath: filePath, contents: nil, attributes: nil)
-		}
-
-		freopen(filePath.toCString(), "a+", stderr)
-
-	}
-
-	func readFile(_ file: UnsafeMutablePointer<FILE>) {
-		let bufsize = 4096
-		let buffer = [CChar](repeating: 0, count: bufsize)
-
-		let buf = UnsafeMutablePointer(mutating: buffer)
-
-		while (fgets(buf, Int32(bufsize-1), file) != nil) {
-			let out = String(cString: buf)
-			print(out)
-		}
-		buf.deinitialize()
 	}
 
 	func updateTitle() {
@@ -304,7 +278,8 @@ class ViewController: UIViewController {
 	}
 
     @objc func clearBufferCommand() {
-        terminalView.clearBuffer()
+        terminalView.clearScreen()
+        terminalView.writePrompt()
     }
 
 //    @objc func selectCommandHome() {
@@ -358,6 +333,29 @@ extension ViewController: UIDocumentPickerDelegate {
 
 }
 
+extension ViewController: CommandExecutorDelegate {
+
+    func commandExecutor(_ commandExecutor: CommandExecutor, receivedStdout stdout: String) {
+        terminalView.writeOutput(sanitizeOutput(stdout))
+    }
+    func commandExecutor(_ commandExecutor: CommandExecutor, receivedStderr stderr: String) {
+        terminalView.writeOutput(sanitizeOutput(stderr))
+    }
+    func commandExecutor(_ commandExecutor: CommandExecutor, didFinishDispatchWithExitCode exitCode: Int32) {
+        terminalView.writePrompt()
+        updateTitle()
+    }
+
+    private func sanitizeOutput(_ output: String) -> String {
+        var output = output
+        // Replace $HOME with "~"
+        output = output.replacingOccurrences(of: DocumentManager.shared.activeDocumentsFolderURL.path, with: "~")
+        // Sometimes, fileManager adds /private in front of the directory
+        output = output.replacingOccurrences(of: "/private", with: "")
+        return output
+    }
+}
+
 extension ViewController: TerminalViewDelegate {
 
 	func didEnterCommand(_ command: String) {
@@ -365,7 +363,51 @@ extension ViewController: TerminalViewDelegate {
 		historyViewController.addCommand(command)
 		commandIndex = 0
 
+        processCommand(command)
 	}
+
+    private func processCommand(_ command: String) {
+
+        // Trim leading/trailing space
+        let command = command.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        // Separate in to command and arguments
+        let components = command.components(separatedBy: .whitespaces)
+        guard components.count > 0 else { return }
+        let program = components[0]
+        let args = Array(components[1..<components.endIndex])
+
+        // Special case for clear
+        if command == "clear" {
+            terminalView.clearScreen()
+            terminalView.writePrompt()
+            return
+        }
+
+        // Special case for help
+        if command == "help" || command == "?" {
+            let commands = availableCommands().joined(separator: ", ")
+            terminalView.writeOutput(commands)
+            terminalView.writePrompt()
+            return
+        }
+
+        // Special case for scripts
+        if Script.allNames.contains(program), let script = try? Script.named(program) {
+            // A script resolves to an array of commands to run. Dispatch each of those.
+            do {
+                let commands = try script.runnableCommands(withArgs: args)
+                executor.dispatch(commands)
+            } catch {
+                terminalView.writeOutput(error.localizedDescription)
+                terminalView.writePrompt()
+            }
+            return
+        }
+
+        // Default case: Dispatch the command to the executor
+        executor.dispatch(command)
+    }
 
 }
 
@@ -382,7 +424,7 @@ extension ViewController: HistoryViewControllerDelegate {
 extension ViewController: PanelManager {
 
 	var panels: [PanelViewController] {
-		return [historyPanelViewController]
+		return [historyPanelViewController, scriptsPanelViewController]
 	}
 
 	var panelContentWrapperView: UIView {
@@ -445,52 +487,4 @@ extension ViewController {
 
 	}
 
-}
-
-extension ViewController: TerminalProcessor {
-
-    func process(command: String, completion: @escaping (String) -> Void) {
-
-		let command = command.trimmingCharacters(in: .whitespacesAndNewlines)
-		
-		let fileManager = DocumentManager.shared.fileManager
-
-		if command == "help" || command == "?" {
-            completion(availableCommands().joined(separator: ", "))
-			return
-		}
-
-        setStdOut()
-        setStdErr()
-
-        DispatchQueue.global(qos: .default).async {
-            let returnCode = ios_system(command.utf8CString)
-
-            DispatchQueue.main.async {
-                self.updateTitle()
-
-                self.readFile(stdout)
-                self.readFile(stderr)
-
-                // when there are both stdout and stderr results we prefer stdout when return code
-                // indicates no error (zero)
-                let errFilePath = NSTemporaryDirectory().appending("err.txt")
-                let stdFilePath = NSTemporaryDirectory().appending("out.txt")
-                let paths = returnCode == 0 ? [stdFilePath, errFilePath] : [errFilePath, stdFilePath]
-
-                for path in paths {
-                    if let data = fileManager.contents(atPath: path) {
-                        if let str = String(data: data, encoding: .utf8) {
-                            if !str.isEmpty {
-                                completion(str)
-                                return
-                            }
-                        }
-                    }
-                }
-
-                completion("")
-            }
-        }
-	}
 }

--- a/OpenTerm/Util/AutoComplete/AutoCompleteManager+InputAssistant.swift
+++ b/OpenTerm/Util/AutoComplete/AutoCompleteManager+InputAssistant.swift
@@ -27,7 +27,7 @@ extension AutoCompleteManager: InputAssistantViewDataSource {
     }
 
     func inputAssistantView(_ inputAssistantView: InputAssistantView, nameForSuggestionAtIndex index: Int) -> String {
-        return self.completions[index]
+        return self.completions[index].name
     }
 }
 

--- a/OpenTerm/Util/AutoComplete/AutoCompleteManager+InputAssistant.swift
+++ b/OpenTerm/Util/AutoComplete/AutoCompleteManager+InputAssistant.swift
@@ -1,0 +1,43 @@
+//
+//  AutoCompleteManager+InputAssistant.swift
+//  OpenTerm
+//
+//  Created by Ian McDowell on 1/30/18.
+//  Copyright © 2018 Silver Fox. All rights reserved.
+//
+
+import Foundation
+import InputAssistant
+
+// This file bridges the auto complete manager with the input assistant view.
+// Using these extensions is optional, but provides a basic implementation for free.
+// To use these, do the following:
+// - Set the AutoCompleteManager's delegate to be the InputAssistantView
+// - Set the InputAssistantView's data source to be the AutoCompleteManager
+
+// Make the input assistant read its suggestions from the manager's completions
+extension AutoCompleteManager: InputAssistantViewDataSource {
+
+    func textForEmptySuggestionsInInputAssistantView() -> String? {
+        return nil
+    }
+
+    func numberOfSuggestionsInInputAssistantView() -> Int {
+        return self.completions.count
+    }
+
+    func inputAssistantView(_ inputAssistantView: InputAssistantView, nameForSuggestionAtIndex index: Int) -> String {
+        return self.completions[index]
+    }
+}
+
+// Make the input assistant reload when completions change
+extension InputAssistantView: AutoCompleteManagerDelegate {
+    func autoCompleteManagerDidChangeState() {
+    }
+
+    func autoCompleteManagerDidChangeCompletions() {
+        // Completions were updated, so display them.
+        self.reloadData()
+    }
+}

--- a/OpenTerm/Util/AutoComplete/AutoCompleteManager.swift
+++ b/OpenTerm/Util/AutoComplete/AutoCompleteManager.swift
@@ -35,9 +35,8 @@ class AutoCompleteManager {
     }
 
     /// The current state, based on the current command.
-    var state: State {
+    private(set) var state: State {
         didSet {
-            print("State: \(state)")
             delegate?.autoCompleteManagerDidChangeState()
         }
     }
@@ -87,7 +86,7 @@ class AutoCompleteManager {
     }
 
     /// Reload state & completions from the data source.
-    private func reloadData() {
+    func reloadData() {
         // Update state based on information from data source.
         if let dataSource = dataSource {
             switch self.state {

--- a/OpenTerm/Util/Execution/CommandExecutionContext.swift
+++ b/OpenTerm/Util/Execution/CommandExecutionContext.swift
@@ -1,0 +1,74 @@
+//
+//  CommandExecutionContext.swift
+//  OpenTerm
+//
+//  Created by iamcdowe on 1/30/18.
+//  Copyright © 2018 Silver Fox. All rights reserved.
+//
+
+import Foundation
+
+/// Stores variables and context about the commands in an executor that are running or have run.
+struct CommandExecutionContext {
+
+    /// Predefined keys for accessing storage
+    enum Key: String {
+
+        /// The exit status of the last command that ran
+        case status
+    }
+
+    private var storage: [String: String]
+
+    init() {
+        storage = [:]
+    }
+
+    /// Access storage from predefined keys
+    subscript(key: Key) -> String? {
+        get { return self[key.rawValue] }
+        set { self[key.rawValue] = newValue }
+    }
+
+    /// Access storage from raw keys.
+    subscript(key: String) -> String? {
+        get { return storage[key] }
+        set { storage[key] = newValue }
+    }
+
+    /// Replaces occurrences of each $variable in the context with its value.
+    func apply(toCommand command: String) -> String {
+        var command = command
+        for (key, value) in storage {
+            let escaped = CommandExecutionContext.escape(string: value)
+            command = command.replacingOccurrences(of: "$\(key)", with: escaped)
+        }
+        return command
+    }
+
+    /// Escapes the string for entering into a command
+    /// Finds the instances of quote (") and backward slash (\) and prepends
+    /// the escape character backward slash (\).
+    private static func escape(string: String) -> String {
+        func needsEscape(_ char: UInt8) -> Bool {
+            return char == UInt8(ascii: "\\") || char == UInt8(ascii: "\"")
+        }
+
+        guard let pos = string.utf8.index(where: needsEscape) else {
+            return string
+        }
+        var newString = String(string[..<pos])
+        for char in string.utf8[pos...] {
+            if needsEscape(char) {
+                newString += "\\"
+            }
+            newString += String(UnicodeScalar(char))
+        }
+
+        // Surround in quotes if it has non-alphanumeric characters.
+        if newString.isEmpty || newString.rangeOfCharacter(from: CharacterSet.alphanumerics.inverted) != nil {
+            return "\"\(newString)\""
+        }
+        return newString
+    }
+}

--- a/OpenTerm/Util/Execution/CommandExecutor.swift
+++ b/OpenTerm/Util/Execution/CommandExecutor.swift
@@ -1,0 +1,98 @@
+//
+//  CommandExecutor.swift
+//  OpenTerm
+//
+//  Created by Ian McDowell on 1/30/18.
+//  Copyright © 2018 Silver Fox. All rights reserved.
+//
+
+import Foundation
+import ios_system
+
+protocol CommandExecutorDelegate: class {
+    func commandExecutor(_ commandExecutor: CommandExecutor, receivedStdout stdout: String)
+    func commandExecutor(_ commandExecutor: CommandExecutor, receivedStderr stderr: String)
+    func commandExecutor(_ commandExecutor: CommandExecutor, didFinishDispatchWithExitCode exitCode: Int32)
+}
+
+/// Utility that executes commands serially to ios_system.
+/// Has its own stdout/stderr, and passes output & results to its delegate.
+class CommandExecutor {
+
+    weak var delegate: CommandExecutorDelegate?
+
+    /// Dispatch queue to serially run commands on.
+    private let queue = DispatchQueue.init(label: "CommandExecutor", qos: .userInteractive)
+
+    private let stdout: Pipe
+    private let stdout_file: UnsafeMutablePointer<FILE>?
+    private let stderr: Pipe
+    private let stderr_file: UnsafeMutablePointer<FILE>?
+
+    init() {
+        // Create a new pipe for stdout/stderr, and get FILE pointers for writing to them
+        stdout = Pipe()
+        stdout_file = fdopen(stdout.fileHandleForWriting.fileDescriptor, "w")
+        stderr = Pipe()
+        stderr_file = fdopen(stderr.fileHandleForWriting.fileDescriptor, "w")
+
+        // Call the following functions when data is written.
+        stdout.fileHandleForReading.readabilityHandler = self.onStdout
+        stderr.fileHandleForReading.readabilityHandler = self.onStderr
+    }
+
+    // Dispatch a new command to execute.
+    func dispatch(_ command: String) {
+        queue.async {
+            let returnCode = self.system(command)
+
+            // Wait a bit to allow final stdout/stderr to get read. TODO: This should not be needed, but it is.
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+                self.delegate?.commandExecutor(self, didFinishDispatchWithExitCode: returnCode)
+            }
+        }
+    }
+
+    // Dispatch a set of commands to run serially. If a command returns a non-zero exit code, subsequent commands do not run.
+    func dispatch(_ commands: [String]) {
+        queue.async {
+            var returnCode: Int32 = 0
+            for command in commands {
+                returnCode = self.system(command)
+                if returnCode != 0 {
+                    break
+                }
+            }
+
+            // Wait a bit to allow final stdout/stderr to get read. TODO: This should not be needed, but it is.
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+                self.delegate?.commandExecutor(self, didFinishDispatchWithExitCode: returnCode)
+            }
+        }
+    }
+
+    // Run ios_system, with stdout/stderr set to ours.
+    private func system(_ command: String) -> Int32 {
+        dispatchPrecondition(condition: .onQueue(queue))
+
+        thread_stdout = self.stdout_file
+        thread_stderr = self.stderr_file
+        return ios_system(command.utf8CString)
+    }
+
+    // Called when the stdout file handle is written to
+    private func onStdout(_ stdout: FileHandle) {
+        guard let str = String.init(data: stdout.availableData, encoding: .utf8) else { return }
+        DispatchQueue.main.async {
+            self.delegate?.commandExecutor(self, receivedStdout: str)
+        }
+    }
+
+    // Called when teh stderr file handle is written to
+    private func onStderr(_ stderr: FileHandle) {
+        guard let str = String.init(data: stderr.availableData, encoding: .utf8) else { return }
+        DispatchQueue.main.async {
+            self.delegate?.commandExecutor(self, receivedStderr: str)
+        }
+    }
+}

--- a/OpenTerm/Util/Execution/CommandExecutor.swift
+++ b/OpenTerm/Util/Execution/CommandExecutor.swift
@@ -15,6 +15,14 @@ protocol CommandExecutorDelegate: class {
     func commandExecutor(_ commandExecutor: CommandExecutor, didFinishDispatchWithExitCode exitCode: Int32)
 }
 
+// Exit status from an ios_system command
+typealias ReturnCode = Int32
+
+protocol CommandExecutorCommand {
+    // Run the command
+    func run() throws -> ReturnCode
+}
+
 /// Utility that executes commands serially to ios_system.
 /// Has its own stdout/stderr, and passes output & results to its delegate.
 class CommandExecutor {
@@ -24,75 +32,97 @@ class CommandExecutor {
     /// Dispatch queue to serially run commands on.
     private let queue = DispatchQueue.init(label: "CommandExecutor", qos: .userInteractive)
 
-    private let stdout: Pipe
-    private let stdout_file: UnsafeMutablePointer<FILE>?
-    private let stderr: Pipe
-    private let stderr_file: UnsafeMutablePointer<FILE>?
+    // Create new pipes for our own stdout/stderr
+    private static let stdout = Pipe()
+    private static let stderr = Pipe()
+    fileprivate static let stdout_file = fdopen(CommandExecutor.stdout.fileHandleForWriting.fileDescriptor, "w")
+    fileprivate static let stderr_file = fdopen(CommandExecutor.stderr.fileHandleForWriting.fileDescriptor, "w")
 
     init() {
-        // Create a new pipe for stdout/stderr, and get FILE pointers for writing to them
-        stdout = Pipe()
-        stdout_file = fdopen(stdout.fileHandleForWriting.fileDescriptor, "w")
-        stderr = Pipe()
-        stderr_file = fdopen(stderr.fileHandleForWriting.fileDescriptor, "w")
-
-        // Call the following functions when data is written.
-        stdout.fileHandleForReading.readabilityHandler = self.onStdout
-        stderr.fileHandleForReading.readabilityHandler = self.onStderr
+        // Call the following functions when data is written to stdout/stderr.
+        CommandExecutor.stdout.fileHandleForReading.readabilityHandler = self.onStdout
+        CommandExecutor.stderr.fileHandleForReading.readabilityHandler = self.onStderr
     }
 
-    // Dispatch a new command to execute.
+    // Dispatch a new text-based command to execute.
     func dispatch(_ command: String) {
         queue.async {
-            let returnCode = self.system(command)
-
-            // Wait a bit to allow final stdout/stderr to get read. TODO: This should not be needed, but it is.
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
-                self.delegate?.commandExecutor(self, didFinishDispatchWithExitCode: returnCode)
-            }
-        }
-    }
-
-    // Dispatch a set of commands to run serially. If a command returns a non-zero exit code, subsequent commands do not run.
-    func dispatch(_ commands: [String]) {
-        queue.async {
-            var returnCode: Int32 = 0
-            for command in commands {
-                returnCode = self.system(command)
-                if returnCode != 0 {
-                    break
+            let returnCode: ReturnCode
+            do {
+                let executorCommand = CommandExecutor.executorCommand(forCommand: command)
+                returnCode = try executorCommand.run()
+            } catch {
+                returnCode = 1
+                // If an error was thrown while running, send it to the stderr
+                DispatchQueue.main.async {
+                    self.delegate?.commandExecutor(self, receivedStderr: error.localizedDescription)
                 }
             }
 
-            // Wait a bit to allow final stdout/stderr to get read. TODO: This should not be needed, but it is.
+            // Wait a bit to allow final stdout/stderr to get read.
+            // TODO: This should not be needed, but it seems without it, output comes in after ios_system returns.
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
                 self.delegate?.commandExecutor(self, didFinishDispatchWithExitCode: returnCode)
             }
         }
     }
 
-    // Run ios_system, with stdout/stderr set to ours.
-    private func system(_ command: String) -> Int32 {
-        dispatchPrecondition(condition: .onQueue(queue))
+    /// Take user-entered command, decide what to do with it, then return an executor command that will do the work.
+    static func executorCommand(forCommand command: String) -> CommandExecutorCommand {
+        // Separate in to command and arguments
+        let components = command.components(separatedBy: .whitespaces)
+        guard components.count > 0 else { return EmptyExecutorCommand() }
+        let program = components[0]
+        let args = Array(components[1..<components.endIndex])
 
-        thread_stdout = self.stdout_file
-        thread_stderr = self.stderr_file
-        return ios_system(command.utf8CString)
+        // Special case for scripts
+        if Script.allNames.contains(program), let script = try? Script.named(program) {
+            return ScriptExecutorCommand(script: script, arguments: args)
+        }
+
+        // Default case: Just execute the string itself
+        return SystemExecutorCommand(command: command)
     }
 
     // Called when the stdout file handle is written to
     private func onStdout(_ stdout: FileHandle) {
-        guard let str = String.init(data: stdout.availableData, encoding: .utf8) else { return }
+        guard let str = String.init(data: stdout.availableData, encoding: .utf8), !str.isEmpty else { return }
         DispatchQueue.main.async {
             self.delegate?.commandExecutor(self, receivedStdout: str)
         }
     }
 
-    // Called when teh stderr file handle is written to
+    // Called when the stderr file handle is written to
     private func onStderr(_ stderr: FileHandle) {
-        guard let str = String.init(data: stderr.availableData, encoding: .utf8) else { return }
+        guard let str = String.init(data: stderr.availableData, encoding: .utf8), !str.isEmpty else { return }
         DispatchQueue.main.async {
             self.delegate?.commandExecutor(self, receivedStderr: str)
         }
+    }
+}
+
+/// Basic implementation of a command, run ios_system
+struct SystemExecutorCommand: CommandExecutorCommand {
+
+    let command: String
+
+    func run() throws -> ReturnCode {
+        // Set the stdout/stderr of the thread to the custom stdout/stderr.
+        thread_stdout = CommandExecutor.stdout_file
+        thread_stderr = CommandExecutor.stderr_file
+
+        // Pass the value of the string to system, return its exit code.
+        let returnCode = ios_system(command.utf8CString)
+        // Flush stdout and stderr before returning, so all output is finished before marking command as complete.
+        fflush(CommandExecutor.stdout_file)
+        fflush(CommandExecutor.stderr_file)
+        return returnCode
+    }
+}
+
+/// No-op command to run.
+struct EmptyExecutorCommand: CommandExecutorCommand {
+    func run() throws -> ReturnCode {
+        return 0
     }
 }

--- a/OpenTerm/Util/Scripting/Script.swift
+++ b/OpenTerm/Util/Scripting/Script.swift
@@ -1,0 +1,112 @@
+//
+//  Script.swift
+//  OpenTerm
+//
+//  Created by iamcdowe on 1/29/18.
+//  Copyright © 2018 Silver Fox. All rights reserved.
+//
+
+import Foundation
+
+private let scriptsDir = DocumentManager.shared.activeDocumentsFolderURL.appendingPathComponent(".scripts")
+
+private enum ScriptError: LocalizedError {
+    case missingArguments(arguments: [String])
+
+    var errorDescription: String? {
+        switch self {
+        case .missingArguments(let arguments): return "Script is missing arguments: \(arguments.joined(separator: ", "))"
+        }
+    }
+}
+
+/// This class contains methods for loading/parsing/executing scripts.
+/// A script is a text file in the .scripts folder, referenced by a unique name (it's file name).
+/// Each script can have a set of named arguments, which are stored in the file in the following format: $<<argument_name>>
+class Script {
+	let name: String
+	var value: String {
+		didSet { save() }
+	}
+
+	private init(name: String, value: String) {
+		self.name = name; self.value = value
+	}
+
+	/// Commands to run, in order.
+	private var commands: [String] { return value.components(separatedBy: .newlines) }
+
+	/// Replace argument templates with argument values
+	func runnableCommands(withArgs args: [String]) throws -> [String] {
+        // Step 1: Parse arguments from "--argname=value" to dictionary ["argname": "value"]
+        let argDict: [String: String] = Dictionary.init(uniqueKeysWithValues: args.flatMap({ arg in
+            let components = arg.components(separatedBy: "=")
+            guard let name = components.first, let value = components.last else { return nil }
+            return (name.replacingOccurrences(of: "--", with: ""), value)
+        }))
+
+        // Step 2: Find missing arguments, if any
+        let providedArgNames = Set(argDict.keys)
+        let requiredArgNames = Set(self.argumentNames)
+        let missingArgs = requiredArgNames.subtracting(providedArgNames)
+        if !missingArgs.isEmpty {
+            throw ScriptError.missingArguments(arguments: missingArgs.sorted())
+        }
+
+        // Step 3: Replace arg format strings with values for each command, return updated commands.
+        return commands.map { command in
+            var command = command
+            for (key, value) in argDict {
+                command = command.replacingOccurrences(of: "$<<\(key)>>", with: value)
+            }
+            return command
+        }
+	}
+
+	/// The names of the arguments, unique, and sorted by name
+	var argumentNames: [String] {
+		let matches = Script.argumentRegex.matches(in: value, options: [], range: NSRange.init(location: 0, length: value.count))
+		return Set(matches.flatMap { result in
+			let match = result.range(at: 1)
+			if let range = Range.init(match, in: value) {
+				return String(value[range])
+			}
+			return nil
+		}).sorted()
+	}
+
+	/// Save the contents of the script to disk
+	private func save() {
+		do {
+			if !DocumentManager.shared.fileManager.fileExists(atPath: scriptsDir.path) {
+				try DocumentManager.shared.fileManager.createDirectory(at: scriptsDir, withIntermediateDirectories: true, attributes: nil)
+			}
+			let scriptFile = scriptsDir.appendingPathComponent(name)
+			try value.write(to: scriptFile, atomically: true, encoding: .utf8)
+		} catch {
+			print("Unable to save script. \(error.localizedDescription)")
+		}
+	}
+
+	static let argumentRegex = try! NSRegularExpression.init(pattern: "\\$<<(\\w+)>>", options: [])
+
+	/// Load the script with the given name from disk.
+	static func named(_ name: String) throws -> Script {
+		let scriptFile = scriptsDir.appendingPathComponent(name)
+		let value = try String.init(contentsOf: scriptFile)
+		return Script(name: name, value: value)
+	}
+
+	/// Get all of the script names
+	static var allNames: [String] {
+		return (try? DocumentManager.shared.fileManager.contentsOfDirectory(atPath: scriptsDir.path)) ?? []
+	}
+
+    // Create a new script, or overwrite an existing one.
+    @discardableResult
+    static func create(_ name: String) -> Script {
+        let script = Script(name: name, value: "")
+        script.save()
+        return script
+    }
+}

--- a/OpenTerm/Util/Scripting/ScriptExecutorCommand.swift
+++ b/OpenTerm/Util/Scripting/ScriptExecutorCommand.swift
@@ -13,8 +13,9 @@ class ScriptExecutorCommand: CommandExecutorCommand {
 
     let script: Script
     let arguments: [String]
-    init(script: Script, arguments: [String]) {
-        self.script = script; self.arguments = arguments
+    let context: CommandExecutionContext
+    init(script: Script, arguments: [String], context: CommandExecutionContext) {
+        self.script = script; self.arguments = arguments; self.context = context
     }
 
     func run() throws -> ReturnCode {
@@ -22,7 +23,7 @@ class ScriptExecutorCommand: CommandExecutorCommand {
 
         var returnCode: Int32 = 0
         for command in commands {
-            let executor = CommandExecutor.executorCommand(forCommand: command)
+            let executor = CommandExecutor.executorCommand(forCommand: command, inContext: self.context)
             returnCode = try executor.run()
             if returnCode != 0 {
                 break

--- a/OpenTerm/Util/Scripting/ScriptExecutorCommand.swift
+++ b/OpenTerm/Util/Scripting/ScriptExecutorCommand.swift
@@ -1,0 +1,34 @@
+//
+//  ScriptExecutorCommand.swift
+//  OpenTerm
+//
+//  Created by iamcdowe on 1/30/18.
+//  Copyright © 2018 Silver Fox. All rights reserved.
+//
+
+import Foundation
+
+/// Implementation for running a script.
+class ScriptExecutorCommand: CommandExecutorCommand {
+
+    let script: Script
+    let arguments: [String]
+    init(script: Script, arguments: [String]) {
+        self.script = script; self.arguments = arguments
+    }
+
+    func run() throws -> ReturnCode {
+        let commands = try script.runnableCommands(withArgs: self.arguments)
+
+        var returnCode: Int32 = 0
+        for command in commands {
+            let executor = CommandExecutor.executorCommand(forCommand: command)
+            returnCode = try executor.run()
+            if returnCode != 0 {
+                break
+            }
+        }
+
+        return returnCode
+    }
+}

--- a/OpenTerm/Util/Scripting/ScriptExecutorCommand.swift
+++ b/OpenTerm/Util/Scripting/ScriptExecutorCommand.swift
@@ -18,13 +18,13 @@ class ScriptExecutorCommand: CommandExecutorCommand {
         self.script = script; self.arguments = arguments; self.context = context
     }
 
-    func run() throws -> ReturnCode {
+    func run(forExecutor executor: CommandExecutor) throws -> ReturnCode {
         let commands = try script.runnableCommands(withArgs: self.arguments)
 
         var returnCode: Int32 = 0
         for command in commands {
-            let executor = CommandExecutor.executorCommand(forCommand: command, inContext: self.context)
-            returnCode = try executor.run()
+            // Run the executor command
+            returnCode = try executor.executorCommand(forCommand: command, inContext: self.context).run(forExecutor: executor)
             if returnCode != 0 {
                 break
             }

--- a/OpenTerm/View/TerminalTextView.swift
+++ b/OpenTerm/View/TerminalTextView.swift
@@ -1,0 +1,66 @@
+//
+//  TerminalTextView.swift
+//  OpenTerm
+//
+//  Created by iamcdowe on 1/29/18.
+//  Copyright © 2018 Silver Fox. All rights reserved.
+//
+
+import UIKit
+
+/// UITextView that adopts the style of a terminal.
+class TerminalTextView: UITextView {
+	
+	override init(frame: CGRect, textContainer: NSTextContainer?) {
+		super.init(frame: frame, textContainer: textContainer)
+
+		setup()
+	}
+	
+	required init?(coder aDecoder: NSCoder) {
+		super.init(coder: aDecoder)
+
+		setup()
+	}
+	
+	private func setup() {
+
+		autocorrectionType = .no
+		smartDashesType = .no
+		smartQuotesType = .no
+		autocapitalizationType = .none
+		spellCheckingType = .no
+
+		indicatorStyle = .white
+
+		updateAppearanceFromSettings()
+
+		NotificationCenter.default.addObserver(self, selector: #selector(self.updateAppearanceFromSettingsAnimated), name: .appearanceDidChange, object: nil)
+	}
+	
+	@objc
+	private func updateAppearanceFromSettingsAnimated() {
+		UIView.animate(withDuration: 0.35) {
+			self.updateAppearanceFromSettings()
+		}
+	}
+	
+	private func updateAppearanceFromSettings() {
+		let userDefaultsController = UserDefaultsController.shared
+
+		let terminalFontSize = userDefaultsController.terminalFontSize
+		self.font = UIFont(name: "Menlo", size: CGFloat(terminalFontSize))
+
+		let terminaltextColor = userDefaultsController.terminalTextColor
+		self.textColor = terminaltextColor
+		self.tintColor = terminaltextColor
+
+		self.backgroundColor = userDefaultsController.terminalBackgroundColor
+
+		if userDefaultsController.userDarkKeyboardInTerminal {
+			self.keyboardAppearance = .dark
+		} else {
+			self.keyboardAppearance = .light
+		}
+	}
+}

--- a/OpenTerm/View/TerminalView.swift
+++ b/OpenTerm/View/TerminalView.swift
@@ -105,7 +105,7 @@ class TerminalView: UIView {
 
     // Moves the cursor to a new line, if it's not already
     func newLine() {
-        if !textView.text.hasSuffix("\n") {
+        if !textView.text.hasSuffix("\n") && !textView.text.isEmpty {
             textView.text = textView.text + "\n"
         }
         currentCommandStartIndex = textView.text.endIndex

--- a/OpenTerm/View/TerminalView.swift
+++ b/OpenTerm/View/TerminalView.swift
@@ -9,12 +9,6 @@
 import UIKit
 import InputAssistant
 
-protocol TerminalProcessor: class {
-
-    func process(command: String, completion: @escaping (String) -> Void)
-
-}
-
 protocol TerminalViewDelegate: class {
 
 	func didEnterCommand(_ command: String)
@@ -25,7 +19,7 @@ protocol TerminalViewDelegate: class {
 class TerminalView: UIView {
 
 	let deviceName = UIDevice.current.name
-	let textView = UITextView()
+	let textView = TerminalTextView()
     let inputAssistantView = InputAssistantView()
     let autoCompleteManager = AutoCompleteManager()
 
@@ -34,8 +28,6 @@ class TerminalView: UIView {
     var currentCommandStartIndex: String.Index! {
         didSet { self.updateAutoComplete() }
     }
-
-	weak var processor: TerminalProcessor?
 
 	weak var delegate: TerminalViewDelegate?
 
@@ -72,22 +64,12 @@ class TerminalView: UIView {
 
 		textView.delegate = self
 
-		textView.text = "\(deviceName): "
-
-		currentCommandStartIndex = textView.text.endIndex
-
-		textView.autocorrectionType = .no
-		textView.smartDashesType = .no
-		textView.smartQuotesType = .no
-		textView.autocapitalizationType = .none
-		textView.spellCheckingType = .no
-
-		textView.indicatorStyle = .white
+		self.writePrompt()
 
 		textView.textDragDelegate = self
 		textView.textDropDelegate = self
 
-        self.setupAutoComplete()
+		self.setupAutoComplete()
 
 		keyboardObserver.observe { (state) in
 
@@ -102,50 +84,37 @@ class TerminalView: UIView {
 
 		}
 
-        updateAppearanceFromSettings()
-
-        NotificationCenter.default.addObserver(self, selector: #selector(self.updateAppearanceFromSettingsAnimated), name: .appearanceDidChange, object: nil)
-
 	}
 
-    @objc
-	func updateAppearanceFromSettingsAnimated() {
-
-		UIView.animate(withDuration: 0.35) {
-
-			self.updateAppearanceFromSettings()
-
-		}
-
+    // Display a prompt at the beginning of the line.
+    func writePrompt() {
+        newLine()
+        textView.text = textView.text + "\(deviceName): "
+        currentCommandStartIndex = textView.text.endIndex
     }
 
-	func updateAppearanceFromSettings() {
+    // Appends the given string to the output, and updates the command start index.
+    func writeOutput(_ string: String) {
+        var string = string
+        if !string.hasSuffix("\n") {
+            string += "\n"
+        }
+        textView.text = textView.text + string
+        currentCommandStartIndex = textView.text.endIndex
+    }
 
-		let userDefaultsController = UserDefaultsController.shared
+    // Moves the cursor to a new line, if it's not already
+    func newLine() {
+        if !textView.text.hasSuffix("\n") {
+            textView.text = textView.text + "\n"
+        }
+        currentCommandStartIndex = textView.text.endIndex
+    }
 
-		let terminalFontSize = userDefaultsController.terminalFontSize
-		self.textView.font = UIFont(name: "Menlo", size: CGFloat(terminalFontSize))
-
-		let terminaltextColor = userDefaultsController.terminalTextColor
-		self.textView.textColor = terminaltextColor
-		self.textView.tintColor = terminaltextColor
-
-		self.textView.backgroundColor = userDefaultsController.terminalBackgroundColor
-
-		if userDefaultsController.userDarkKeyboardInTerminal {
-			textView.keyboardAppearance = .dark
-		} else {
-			textView.keyboardAppearance = .light
-		}
-
-	}
-
+    // Clears the contents of the screen, resetting the terminal.
 	func clearScreen() {
-
 		currentCommandStartIndex = nil
-		textView.text = "\(deviceName): "
-		currentCommandStartIndex = textView.text.endIndex
-
+		textView.text = ""
 	}
 
 	@discardableResult
@@ -156,7 +125,7 @@ class TerminalView: UIView {
 	var currentCommand: String {
 		get {
 
-			guard let currentCommandStartIndex = currentCommandStartIndex else {
+			guard let currentCommandStartIndex = currentCommandStartIndex, currentCommandStartIndex <= textView.text.endIndex else {
 				return ""
 			}
 
@@ -166,7 +135,7 @@ class TerminalView: UIView {
 		}
 		set {
 
-			if let currentCommandStartIndex = currentCommandStartIndex {
+			if let currentCommandStartIndex = currentCommandStartIndex, currentCommandStartIndex <= textView.text.endIndex {
 				let currentCmdRange = currentCommandStartIndex..<textView.text.endIndex
 				textView.text.replaceSubrange(currentCmdRange, with: "")
 			}
@@ -220,46 +189,14 @@ extension TerminalView: UITextViewDelegate {
 
 		if text == "\n" {
 
-			if let processor = processor {
-
-				let input = textView.text[currentCommandStartIndex..<textView.text.endIndex]
-
-				if !input.isEmpty {
-					delegate?.didEnterCommand(String(input))
-				}
-
-				if input.trimmingCharacters(in: .whitespacesAndNewlines) == "clear" {
-
-					clearScreen()
-
-					return false
-
-				} else {
-
-					self.isWaitingForCommand = true
-
-                    processor.process(command: String(input), completion: { output in
-
-						self.isWaitingForCommand = false
-
-                        let outputParsed = output.replacingOccurrences(of: DocumentManager.shared.activeDocumentsFolderURL.path, with: "~")
-                        // Sometimes, fileManager adds /private in front of the directory
-                        let outputParsed2 = outputParsed.replacingOccurrences(of: "/private", with: "")
-                        if !outputParsed2.isEmpty {
-                            textView.text = textView.text + "\n\(outputParsed2)"
-                        }
-
-                        textView.text = textView.text + "\n\(self.deviceName): "
-                        self.currentCommandStartIndex = textView.text.endIndex
-
-                    })
-					return false
-				}
-
-			}
-
-			textView.text = textView.text + "\n\(deviceName): "
-			currentCommandStartIndex = textView.text.endIndex
+            let input = textView.text[currentCommandStartIndex..<textView.text.endIndex]
+            
+            if input.isEmpty {
+                writePrompt()
+            } else {
+                newLine()
+                delegate?.didEnterCommand(String(input))
+            }
 			return false
 		}
 
@@ -270,12 +207,4 @@ extension TerminalView: UITextViewDelegate {
         updateAutoComplete()
 	}
 
-}
-
-extension TerminalView {
-    func clearBuffer() {
-        currentCommandStartIndex = nil
-        textView.text = "\(deviceName): "
-        currentCommandStartIndex = textView.text.endIndex
-    }
 }


### PR DESCRIPTION
Major changes:
- Moved command execution to a new CommandExecutor class, which calls into ios_system, and can run multiple commands at once (in series, put on a dispatch queue).
- Streaming stdout/stderr to UITextView as it comes in. Using a Pipe & File Handle to accomplish this.
- Added ScriptsViewController & ScriptEditViewController, for managing and editing scripts in a GUI.
- Added Script class, that handles script management (creating/loading/editing/running). Scripts are stored in Documents/.scripts
- Refactored AutoCompleteManagerDelegate & InputAssistantViewDataSource conformances into a shared file.
- Refactored TerminalView's UITextView into a UITextView subclass "TerminalTextView", which is shared between terminal view and ScriptEditViewController.
- Removed TerminalProcessor protocol (replaced by CommandExecutor)

Validation:
Tested basic commands, running scripts on iPhone X (iOS 11.3), iPad Pro 9.7" (iOS 11.2.1)
No regressions found. All gui for scripts work.