### PR TITLE
Add history to auto complete, persist history to disk using new HistoryManager

### DIFF
--- a/OpenTerm.xcodeproj/project.pbxproj
+++ b/OpenTerm.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		3C2E4374201EF67C00E4254A /* TerminalView+AutoComplete.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C2E4373201EF67C00E4254A /* TerminalView+AutoComplete.swift */; };
 		3C2E4385201EFF4700E4254A /* AutoCompleteManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C2E4384201EFF4700E4254A /* AutoCompleteManager.swift */; };
+		3CA3210E2021400100974B5F /* HistoryManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CA3210D2021400100974B5F /* HistoryManager.swift */; };
 		5A38CC73C499E1A878353871 /* Pods_OpenTerm.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FC01604DAC695ABD64544260 /* Pods_OpenTerm.framework */; };
 		BE000C081FEC4F6C00D06B91 /* ios_system.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BE3768EE1FEC4DCE00D5A2D1 /* ios_system.framework */; settings = {ATTRIBUTES = (Required, ); }; };
 		BE000C091FEC4F6F00D06B91 /* ios_system.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BE3768EE1FEC4DCE00D5A2D1 /* ios_system.framework */; settings = {ATTRIBUTES = (Required, ); }; };
@@ -52,6 +53,7 @@
 		24F6A88F715402F565B82F26 /* Pods-Terminal.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Terminal.release.xcconfig"; path = "Pods/Target Support Files/Pods-Terminal/Pods-Terminal.release.xcconfig"; sourceTree = "<group>"; };
 		3C2E4373201EF67C00E4254A /* TerminalView+AutoComplete.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TerminalView+AutoComplete.swift"; sourceTree = "<group>"; };
 		3C2E4384201EFF4700E4254A /* AutoCompleteManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoCompleteManager.swift; sourceTree = "<group>"; };
+		3CA3210D2021400100974B5F /* HistoryManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HistoryManager.swift; sourceTree = "<group>"; };
 		448CC7691FD84EB5D2C24705 /* Pods-OpenTerm.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-OpenTerm.debug.xcconfig"; path = "Pods/Target Support Files/Pods-OpenTerm/Pods-OpenTerm.debug.xcconfig"; sourceTree = "<group>"; };
 		83138AA9A57F46310B4DFF53 /* Pods_Terminal.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Terminal.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		BE165407201909030067EC92 /* xCallBackUrl.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = xCallBackUrl.swift; sourceTree = "<group>"; };
@@ -96,6 +98,14 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		3CA3210C20213FF700974B5F /* History */ = {
+			isa = PBXGroup;
+			children = (
+				3CA3210D2021400100974B5F /* HistoryManager.swift */,
+			);
+			path = History;
+			sourceTree = "<group>";
+		};
 		BE244DC6201FBB4F00A7EA4E /* Default certs */ = {
 			isa = PBXGroup;
 			children = (
@@ -174,6 +184,7 @@
 		BEA8E28F2001346D00002475 /* Util */ = {
 			isa = PBXGroup;
 			children = (
+				3CA3210C20213FF700974B5F /* History */,
 				BEA8E2902001348C00002475 /* UIColor+AssetCatalog.swift */,
 				F4602B48200A63FC009D0547 /* UserDefaults+UIColor.swift */,
 				BEA4992D1FDC305B001B9B9D /* KeyboardObserver.swift */,
@@ -352,6 +363,7 @@
 				BE505066201E5ED900CDFC60 /* Share.swift in Sources */,
 				BEECFF0A1FFC1DC0009608B3 /* HistoryViewController.swift in Sources */,
 				BEA4992E1FDC305B001B9B9D /* KeyboardObserver.swift in Sources */,
+				3CA3210E2021400100974B5F /* HistoryManager.swift in Sources */,
 				F4602B41200A08D0009D0547 /* ColorPickerViewController.swift in Sources */,
 				BE9275062013961D00BD2761 /* UserDefaultsController.swift in Sources */,
 				BE3808561FD9BFB600393EB8 /* AppDelegate.swift in Sources */,

--- a/OpenTerm/Controller/HistoryViewController.swift
+++ b/OpenTerm/Controller/HistoryViewController.swift
@@ -17,14 +17,12 @@ protocol HistoryViewControllerDelegate: class {
 
 class HistoryViewController: UIViewController {
 
-	var commands = [String]()
-
 	weak var delegate: HistoryViewControllerDelegate?
 
 	@IBOutlet weak var tableView: UITableView!
 
-    override func viewDidLoad() {
-        super.viewDidLoad()
+	override func viewDidLoad() {
+		super.viewDidLoad()
 
 		self.title = "History"
 		self.view.tintColor = .defaultMainTintColor
@@ -33,18 +31,9 @@ class HistoryViewController: UIViewController {
 		tableView.dataSource = self
 		tableView.delegate = self
 
-    }
-
-	func addCommand(_ command: String) {
-
-		tableView.performBatchUpdates({
-
-			self.commands.append(command)
-			self.tableView.insertRows(at: [IndexPath(row: 0, section: 0)], with: .automatic)
-
-		}, completion: nil)
-
+		NotificationCenter.default.addObserver(self.tableView, selector: #selector(UITableView.reloadData), name: .historyDidChange, object: nil)
 	}
+
 
 	override var preferredStatusBarStyle: UIStatusBarStyle {
 		return .lightContent
@@ -59,7 +48,7 @@ extension HistoryViewController: UITableViewDataSource {
 	}
 
 	func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-		return commands.count
+		return HistoryManager.history.count
 	}
 
 	func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
@@ -67,7 +56,7 @@ extension HistoryViewController: UITableViewDataSource {
 		let cell = UITableViewCell(style: .default, reuseIdentifier: "cell")
 
 		cell.backgroundColor = self.view.backgroundColor
-		cell.textLabel?.text = commands.reversed()[indexPath.row]
+		cell.textLabel?.text = HistoryManager.history[indexPath.row]
 		cell.textLabel?.textColor = .white
 		cell.textLabel?.font = UIFont(name: "Menlo", size: 16)
 
@@ -82,7 +71,7 @@ extension HistoryViewController: UITableViewDelegate {
 
 		tableView.deselectRow(at: indexPath, animated: true)
 
-		let commandSelected = commands.reversed()[indexPath.row]
+		let commandSelected = HistoryManager.history[indexPath.row]
 		delegate?.didSelectCommand(command: commandSelected)
 
 		if let panelVC = self.panelNavigationController?.panelViewController {

--- a/OpenTerm/Controller/ViewController.swift
+++ b/OpenTerm/Controller/ViewController.swift
@@ -156,7 +156,7 @@ class ViewController: UIViewController {
 			return
 		}
 
-		if historyViewController.commands.count > 5 {
+		if HistoryManager.history.count > 5 {
 			SKStoreReviewController.requestReview()
 			didRequestReview = true
 		}
@@ -277,13 +277,13 @@ class ViewController: UIViewController {
 
 	@objc func selectPreviousCommand() {
 
-		guard commandIndex < historyViewController.commands.count else {
+		guard commandIndex < HistoryManager.history.count else {
 			return
 		}
 
 		commandIndex += 1
 
-		terminalView.currentCommand = historyViewController.commands.reversed()[commandIndex - 1]
+		terminalView.currentCommand = HistoryManager.history[commandIndex - 1]
 
 	}
 
@@ -298,7 +298,7 @@ class ViewController: UIViewController {
 		if commandIndex == 0 {
 			terminalView.currentCommand = ""
 		} else {
-			terminalView.currentCommand = historyViewController.commands.reversed()[commandIndex - 1]
+			terminalView.currentCommand = HistoryManager.history[commandIndex - 1]
 		}
 
 	}
@@ -362,7 +362,7 @@ extension ViewController: TerminalViewDelegate {
 
 	func didEnterCommand(_ command: String) {
 
-		historyViewController.addCommand(command)
+		HistoryManager.add(command)
 		commandIndex = 0
 
 	}

--- a/OpenTerm/Util/AutoCompleteManager.swift
+++ b/OpenTerm/Util/AutoCompleteManager.swift
@@ -87,7 +87,7 @@ class AutoCompleteManager {
     }
 
     /// Reload state & completions from the data source.
-    private func reloadData() {
+    func reloadData() {
         // Update state based on information from data source.
         if let dataSource = dataSource {
             switch self.state {

--- a/OpenTerm/Util/History/HistoryManager.swift
+++ b/OpenTerm/Util/History/HistoryManager.swift
@@ -1,0 +1,53 @@
+//
+//  HistoryManager.swift
+//  OpenTerm
+//
+//  Created by iamcdowe on 1/30/18.
+//  Copyright © 2018 Silver Fox. All rights reserved.
+//
+
+import Foundation
+
+extension Notification.Name {
+    static let historyDidChange = Notification.Name("HistoryManagerHistoryDidChangeNotification")
+}
+
+class HistoryManager {
+
+    /// List of commands run. Latest is first.
+    private(set) static var history: [String] = loadHistory() {
+        didSet {
+            NotificationCenter.default.post(name: .historyDidChange, object: nil)
+        }
+    }
+
+    /// Add the command that the user ran to the history.
+    static func add(_ command: String) {
+        let command = command.trimmingCharacters(in: .whitespacesAndNewlines)
+        if command.isEmpty { return }
+        do {
+            if !DocumentManager.shared.fileManager.fileExists(atPath: historyFileURL.path) {
+                try command.write(to: historyFileURL, atomically: true, encoding: .utf8)
+            } else {
+                let fileHandle = try FileHandle.init(forWritingTo: historyFileURL)
+                if let value = (command + "\n").data(using: .utf8) {
+                    fileHandle.write(value)
+                }
+            }
+            history.insert(command, at: 0)
+        } catch {
+            assertionFailure("Unable to add to history.")
+        }
+    }
+
+    private static let historyFileURL = DocumentManager.shared.activeDocumentsFolderURL.appendingPathComponent(".history")
+    private static func loadHistory() -> [String] {
+        do {
+            let string = try String.init(contentsOf: historyFileURL)
+            return string.components(separatedBy: .newlines).filter{ !$0.isEmpty }.reversed()
+        } catch {
+            return []
+        }
+    }
+}
+

--- a/OpenTerm/View/TerminalView+AutoComplete.swift
+++ b/OpenTerm/View/TerminalView+AutoComplete.swift
@@ -56,6 +56,8 @@ extension TerminalView {
 
         // Disable built-in autocomplete
         textView.autocorrectionType = .no
+
+        NotificationCenter.default.addObserver(self, selector: #selector(historyDidChange), name: .historyDidChange, object: nil)
     }
 
     /// Updates auto complete when current command changes
@@ -66,6 +68,10 @@ extension TerminalView {
     /// Dismiss the keyboard when the down arrow is tapped
     @objc private func downTapped() {
         textView.resignFirstResponder()
+    }
+
+    @objc private func historyDidChange() {
+        autoCompleteManager.reloadData()
     }
 
     /// Construct an image for the down arrow.
@@ -107,7 +113,8 @@ extension TerminalView: AutoCompleteManagerDataSource {
 
     func allCommandsForAutoCompletion() -> [String] {
         let allCommands = (commandsAsArray() as? [String] ?? []).sorted()
-        return allCommands + ["help", "clear"]
+        let recentHistory = uniqueItemsInRecentHistory()
+        return recentHistory + allCommands + ["help", "clear"]
     }
 
     func optionsForCommand(_ command: String) -> [String] {
@@ -132,13 +139,25 @@ extension TerminalView: AutoCompleteManagerDataSource {
         return options
     }
 
+    private func uniqueItemsInRecentHistory() -> [String] {
+        let recents = Array(HistoryManager.history.prefix(4))
+        var seen = Set<String>()
+        return recents.filter { recent in
+            if seen.contains(recent) {
+                return false
+            }
+            seen.insert(recent)
+            return true
+        }
+    }
+
     // Get the names of files/folders in the current working directory.
     private func itemsInCurrentDirectory(showFolders: Bool, showFiles: Bool) -> [String] {
         if !showFolders && !showFiles { return [] }
 
         let fileManager = DocumentManager.shared.fileManager
         do {
-            let contents = try fileManager.contentsOfDirectory(at: URL(fileURLWithPath: fileManager.currentDirectoryPath), includingPropertiesForKeys: [.isDirectoryKey], options: [])
+            let contents = try fileManager.contentsOfDirectory(at: URL(fileURLWithPath: fileManager.currentDirectoryPath), includingPropertiesForKeys: [.isDirectoryKey], options: .skipsHiddenFiles)
             let files = try contents.filter { url in
                 let resourceValues = try url.resourceValues(forKeys: [.isDirectoryKey])
                 let isDirectory = resourceValues.isDirectory ?? false


### PR DESCRIPTION
- Add the 4 most recent commands (without duplicates) to the auto complete bar.
- Store the history in a new-line delimited file at `~/.history`
- Refactor HistoryViewController to read from file.

This fixes #51.