### PR TITLE
Implemented auto complete & tab complete for paths

### DIFF
--- a/OpenTerm/Controller/Scripting/ScriptEditViewController.swift
+++ b/OpenTerm/Controller/Scripting/ScriptEditViewController.swift
@@ -77,12 +77,17 @@ extension ScriptEditViewController: UITextViewDelegate {
 }
 
 extension ScriptEditViewController: AutoCompleteManagerDataSource {
+
     func allCommandsForAutoCompletion() -> [String] {
         return ["+ new argument"] + self.script.argumentNames
     }
 
-    func completionsForCommand(_ command: String) -> [AutoCompleteManager.Completion] {
+    func completionsForProgram(_ command: String, _ currentArguments: [String]) -> [AutoCompleteManager.Completion] {
         return []
+    }
+
+    func availableCompletions(in completions: [AutoCompleteManager.Completion], forArguments arguments: [String]) -> [AutoCompleteManager.Completion] {
+        return completions
     }
 }
 

--- a/OpenTerm/Controller/ViewController.swift
+++ b/OpenTerm/Controller/ViewController.swift
@@ -297,24 +297,10 @@ class ViewController: UIViewController {
     }
 
     @objc func completeCommand() {
-        guard
-            let firstCompletion = terminalView.autoCompleteManager.completions.first?.name,
-            terminalView.currentCommand != firstCompletion
-            else { return }
-
-        let completed: String
-        if let lastCommand = terminalView.currentCommand.components(separatedBy: " ").last {
-            if lastCommand.isEmpty {
-                completed = terminalView.currentCommand + firstCompletion
-            } else {
-                completed = terminalView.currentCommand.replacingOccurrences(of: lastCommand, with: firstCompletion, options: .backwards)
-            }
-        } else {
-            completed = firstCompletion
+        // When tab key is pressed, insert first completion, if we have one.
+        if let firstCompletion = terminalView.autoCompleteManager.completions.first {
+            terminalView.insertCompletion(firstCompletion)
         }
-
-        terminalView.currentCommand = completed
-        terminalView.autoCompleteManager.reloadData()
     }
 
 	override var keyCommands: [UIKeyCommand]? {

--- a/OpenTerm/Util/DocumentManager.swift
+++ b/OpenTerm/Util/DocumentManager.swift
@@ -48,6 +48,10 @@ class DocumentManager {
 		return ubiquityContainerURL?.appendingPathComponent("Documents")
 	}
 
+    var currentDirectoryURL: URL {
+        return URL(fileURLWithPath: fileManager.currentDirectoryPath).standardizedFileURL
+    }
+
 	var activeDocumentsFolderURL: URL {
 
 		if let cloudDocumentsURL = cloudDocumentsURL {


### PR DESCRIPTION
For a demo of this, see [this tweet](https://twitter.com/ian_mcdowell/status/959568246583144448).

This change:
- Updates logic for showing available completions, and selecting completions, to support paths.
- Refactors auto complete & tab complete to use the same completion logic
- Reloads auto complete manager when arguments change, not just commands
- Stores current argument state in `AutoCompleteManager.state`
- Moves filtering of options to the `AutoCompleteManagerDataSource`