### PR TITLE
Clean up OpenTerm xcodeproj

### DIFF
--- a/OpenTerm.xcodeproj/project.pbxproj
+++ b/OpenTerm.xcodeproj/project.pbxproj
@@ -8,19 +8,17 @@
 
 /* Begin PBXBuildFile section */
 		1C81BE5720225C3800D07301 /* Clipboard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C81BE5620225C3800D07301 /* Clipboard.swift */; };
-		228541D8201FB62C00B93589 /* libfiles.dylib in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 228541D7201FB62C00B93589 /* libfiles.dylib */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
-		22854240201FC4E700B93589 /* libtar.dylib in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 2285423F201FC4E700B93589 /* libtar.dylib */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
-		229EC3CE2024537D004E76C6 /* PanelKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 229EC3CD2024537C004E76C6 /* PanelKit.framework */; };
-		229EC3CF20245527004E76C6 /* ios_system.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 228541DC201FB78200B93589 /* ios_system.framework */; };
-		229EC3D020245527004E76C6 /* ios_system.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 228541DC201FB78200B93589 /* ios_system.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		22AC09DC202056D6006F7D8B /* libcurl.dylib in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 22AC09DB202056D6006F7D8B /* libcurl.dylib */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
-		22D56F8B200268E90090C1F6 /* (null) in Embed Frameworks */ = {isa = PBXBuildFile; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		22F5682A2020CA2E009850FD /* libshell.dylib in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 22F568242020CA2E009850FD /* libshell.dylib */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
-		22F5682B2020CA2E009850FD /* libssh_cmd.dylib in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 22F568252020CA2E009850FD /* libssh_cmd.dylib */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
-		22F5682C2020CA2E009850FD /* libawk.dylib in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 22F568272020CA2E009850FD /* libawk.dylib */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
-		22F5682E2020CA67009850FD /* libtext.dylib in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 22F5682D2020CA66009850FD /* libtext.dylib */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
 		28CDA426202444CC0055206D /* BookmarkViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28CDA425202444CC0055206D /* BookmarkViewController.swift */; };
 		28CDA4292024B3510055206D /* BookmarkManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28CDA4282024B3510055206D /* BookmarkManager.swift */; };
+		3C1A47AA2031357500D7CC5C /* libawk.dylib in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 3C1A479F2031355700D7CC5C /* libawk.dylib */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
+		3C1A47AB2031357500D7CC5C /* libcurl.dylib in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 3C1A479E2031355700D7CC5C /* libcurl.dylib */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
+		3C1A47AC2031357500D7CC5C /* libfiles.dylib in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 3C1A47A02031355700D7CC5C /* libfiles.dylib */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
+		3C1A47AD2031357500D7CC5C /* libshell.dylib in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 3C1A47A12031355700D7CC5C /* libshell.dylib */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
+		3C1A47AE2031357500D7CC5C /* libssh_cmd.dylib in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 3C1A47A22031355700D7CC5C /* libssh_cmd.dylib */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
+		3C1A47AF2031357500D7CC5C /* libtar.dylib in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 3C1A47A32031355700D7CC5C /* libtar.dylib */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
+		3C1A47B02031357500D7CC5C /* ios_system.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = BE3768EE1FEC4DCE00D5A2D1 /* ios_system.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		3C1A47B12031357500D7CC5C /* Pods_OpenTerm.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = FC01604DAC695ABD64544260 /* Pods_OpenTerm.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		3C1A47B22031357B00D7CC5C /* ios_system.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BE3768EE1FEC4DCE00D5A2D1 /* ios_system.framework */; };
 		3C2E4374201EF67C00E4254A /* TerminalView+AutoComplete.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C2E4373201EF67C00E4254A /* TerminalView+AutoComplete.swift */; };
 		3C2E4385201EFF4700E4254A /* AutoCompleteManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C2E4384201EFF4700E4254A /* AutoCompleteManager.swift */; };
 		3C406E1A20207CE7005F97C4 /* CommandExecutor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C406E1920207CE7005F97C4 /* CommandExecutor.swift */; };
@@ -39,8 +37,6 @@
 		3CE5769E202A7EC500760E43 /* Parser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CE5769D202A7EC500760E43 /* Parser.swift */; };
 		3CE576A0202A874C00760E43 /* OutputSanitizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CE5769F202A874C00760E43 /* OutputSanitizer.swift */; };
 		5A38CC73C499E1A878353871 /* Pods_OpenTerm.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FC01604DAC695ABD64544260 /* Pods_OpenTerm.framework */; };
-		BE000C081FEC4F6C00D06B91 /* ios_system.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BE3768EE1FEC4DCE00D5A2D1 /* ios_system.framework */; settings = {ATTRIBUTES = (Required, ); }; };
-		BE000C091FEC4F6F00D06B91 /* ios_system.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BE3768EE1FEC4DCE00D5A2D1 /* ios_system.framework */; settings = {ATTRIBUTES = (Required, ); }; };
 		BE165408201909040067EC92 /* xCallBackUrl.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE165407201909030067EC92 /* xCallBackUrl.swift */; };
 		BE244DC8201FBB6000A7EA4E /* cacert.pem in Resources */ = {isa = PBXBuildFile; fileRef = BE244DC7201FBB6000A7EA4E /* cacert.pem */; };
 		BE3808561FD9BFB600393EB8 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE3808551FD9BFB600393EB8 /* AppDelegate.swift */; };
@@ -80,15 +76,14 @@
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
-				22F5682E2020CA67009850FD /* libtext.dylib in Embed Frameworks */,
-				22F5682A2020CA2E009850FD /* libshell.dylib in Embed Frameworks */,
-				22F5682B2020CA2E009850FD /* libssh_cmd.dylib in Embed Frameworks */,
-				22854240201FC4E700B93589 /* libtar.dylib in Embed Frameworks */,
-				22F5682C2020CA2E009850FD /* libawk.dylib in Embed Frameworks */,
-				22AC09DC202056D6006F7D8B /* libcurl.dylib in Embed Frameworks */,
-				228541D8201FB62C00B93589 /* libfiles.dylib in Embed Frameworks */,
-				22D56F8B200268E90090C1F6 /* (null) in Embed Frameworks */,
-				229EC3D020245527004E76C6 /* ios_system.framework in Embed Frameworks */,
+				3C1A47AA2031357500D7CC5C /* libawk.dylib in Embed Frameworks */,
+				3C1A47AB2031357500D7CC5C /* libcurl.dylib in Embed Frameworks */,
+				3C1A47AC2031357500D7CC5C /* libfiles.dylib in Embed Frameworks */,
+				3C1A47AD2031357500D7CC5C /* libshell.dylib in Embed Frameworks */,
+				3C1A47AE2031357500D7CC5C /* libssh_cmd.dylib in Embed Frameworks */,
+				3C1A47AF2031357500D7CC5C /* libtar.dylib in Embed Frameworks */,
+				3C1A47B02031357500D7CC5C /* ios_system.framework in Embed Frameworks */,
+				3C1A47B12031357500D7CC5C /* Pods_OpenTerm.framework in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -97,21 +92,14 @@
 
 /* Begin PBXFileReference section */
 		1C81BE5620225C3800D07301 /* Clipboard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Clipboard.swift; sourceTree = "<group>"; };
-		228541D7201FB62C00B93589 /* libfiles.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; path = libfiles.dylib; sourceTree = BUILT_PRODUCTS_DIR; };
-		228541DC201FB78200B93589 /* ios_system.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = ios_system.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		2285423F201FC4E700B93589 /* libtar.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; path = libtar.dylib; sourceTree = BUILT_PRODUCTS_DIR; };
-		229EC3CD2024537C004E76C6 /* PanelKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = PanelKit.framework; path = Dependencies/PanelKit.framework; sourceTree = "<group>"; };
-		22AC09DB202056D6006F7D8B /* libcurl.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; path = libcurl.dylib; sourceTree = BUILT_PRODUCTS_DIR; };
-		22F568242020CA2E009850FD /* libshell.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; path = libshell.dylib; sourceTree = BUILT_PRODUCTS_DIR; };
-		22F568252020CA2E009850FD /* libssh_cmd.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; path = libssh_cmd.dylib; sourceTree = BUILT_PRODUCTS_DIR; };
-		22F568262020CA2E009850FD /* libtar.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; path = libtar.dylib; sourceTree = BUILT_PRODUCTS_DIR; };
-		22F568272020CA2E009850FD /* libawk.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; path = libawk.dylib; sourceTree = BUILT_PRODUCTS_DIR; };
-		22F568282020CA2E009850FD /* libcurl.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; path = libcurl.dylib; sourceTree = BUILT_PRODUCTS_DIR; };
-		22F568292020CA2E009850FD /* libfiles.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; path = libfiles.dylib; sourceTree = BUILT_PRODUCTS_DIR; };
-		22F5682D2020CA66009850FD /* libtext.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; path = libtext.dylib; sourceTree = BUILT_PRODUCTS_DIR; };
-		24F6A88F715402F565B82F26 /* Pods-Terminal.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Terminal.release.xcconfig"; path = "Pods/Target Support Files/Pods-Terminal/Pods-Terminal.release.xcconfig"; sourceTree = "<group>"; };
 		28CDA425202444CC0055206D /* BookmarkViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BookmarkViewController.swift; sourceTree = "<group>"; };
 		28CDA4282024B3510055206D /* BookmarkManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookmarkManager.swift; sourceTree = "<group>"; };
+		3C1A479E2031355700D7CC5C /* libcurl.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; path = libcurl.dylib; sourceTree = BUILT_PRODUCTS_DIR; };
+		3C1A479F2031355700D7CC5C /* libawk.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; path = libawk.dylib; sourceTree = BUILT_PRODUCTS_DIR; };
+		3C1A47A02031355700D7CC5C /* libfiles.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; path = libfiles.dylib; sourceTree = BUILT_PRODUCTS_DIR; };
+		3C1A47A12031355700D7CC5C /* libshell.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; path = libshell.dylib; sourceTree = BUILT_PRODUCTS_DIR; };
+		3C1A47A22031355700D7CC5C /* libssh_cmd.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; path = libssh_cmd.dylib; sourceTree = BUILT_PRODUCTS_DIR; };
+		3C1A47A32031355700D7CC5C /* libtar.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; path = libtar.dylib; sourceTree = BUILT_PRODUCTS_DIR; };
 		3C2E4373201EF67C00E4254A /* TerminalView+AutoComplete.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TerminalView+AutoComplete.swift"; sourceTree = "<group>"; };
 		3C2E4384201EFF4700E4254A /* AutoCompleteManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoCompleteManager.swift; sourceTree = "<group>"; };
 		3C406E1920207CE7005F97C4 /* CommandExecutor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommandExecutor.swift; sourceTree = "<group>"; };
@@ -129,7 +117,6 @@
 		3CE5769D202A7EC500760E43 /* Parser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Parser.swift; sourceTree = "<group>"; };
 		3CE5769F202A874C00760E43 /* OutputSanitizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OutputSanitizer.swift; sourceTree = "<group>"; };
 		448CC7691FD84EB5D2C24705 /* Pods-OpenTerm.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-OpenTerm.debug.xcconfig"; path = "Pods/Target Support Files/Pods-OpenTerm/Pods-OpenTerm.debug.xcconfig"; sourceTree = "<group>"; };
-		83138AA9A57F46310B4DFF53 /* Pods_Terminal.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Terminal.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		BE165407201909030067EC92 /* xCallBackUrl.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = xCallBackUrl.swift; sourceTree = "<group>"; };
 		BE244DC7201FBB6000A7EA4E /* cacert.pem */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = cacert.pem; sourceTree = "<group>"; };
 		BE3768EE1FEC4DCE00D5A2D1 /* ios_system.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = ios_system.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -155,7 +142,6 @@
 		BEECFF091FFC1DC0009608B3 /* HistoryViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = HistoryViewController.swift; path = OpenTerm/Controller/History/HistoryViewController.swift; sourceTree = SOURCE_ROOT; };
 		BEECFF381FFEC187009608B3 /* SettingsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = SettingsViewController.swift; path = OpenTerm/Controller/Settings/SettingsViewController.swift; sourceTree = SOURCE_ROOT; };
 		D4433523D5E174B363623AD4 /* Pods-OpenTerm.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-OpenTerm.release.xcconfig"; path = "Pods/Target Support Files/Pods-OpenTerm/Pods-OpenTerm.release.xcconfig"; sourceTree = "<group>"; };
-		D73213876015994510AC49C0 /* Pods-Terminal.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Terminal.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Terminal/Pods-Terminal.debug.xcconfig"; sourceTree = "<group>"; };
 		F456629D200B9BC500C574AA /* ColorDisplayView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColorDisplayView.swift; sourceTree = "<group>"; };
 		F4602B40200A08D0009D0547 /* ColorPickerViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColorPickerViewController.swift; sourceTree = "<group>"; };
 		F4602B48200A63FC009D0547 /* UserDefaults+UIColor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UserDefaults+UIColor.swift"; sourceTree = "<group>"; };
@@ -167,11 +153,8 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				BE000C081FEC4F6C00D06B91 /* ios_system.framework in Frameworks */,
-				BE000C091FEC4F6F00D06B91 /* ios_system.framework in Frameworks */,
-				229EC3CF20245527004E76C6 /* ios_system.framework in Frameworks */,
-				229EC3CE2024537D004E76C6 /* PanelKit.framework in Frameworks */,
 				5A38CC73C499E1A878353871 /* Pods_OpenTerm.framework in Frameworks */,
+				3C1A47B22031357B00D7CC5C /* ios_system.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -294,9 +277,13 @@
 		BE3768EC1FEC4DCE00D5A2D1 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				229EC3CD2024537C004E76C6 /* PanelKit.framework */,
+				3C1A479F2031355700D7CC5C /* libawk.dylib */,
+				3C1A479E2031355700D7CC5C /* libcurl.dylib */,
+				3C1A47A02031355700D7CC5C /* libfiles.dylib */,
+				3C1A47A12031355700D7CC5C /* libshell.dylib */,
+				3C1A47A22031355700D7CC5C /* libssh_cmd.dylib */,
+				3C1A47A32031355700D7CC5C /* libtar.dylib */,
 				BE3768EE1FEC4DCE00D5A2D1 /* ios_system.framework */,
-				83138AA9A57F46310B4DFF53 /* Pods_Terminal.framework */,
 				FC01604DAC695ABD64544260 /* Pods_OpenTerm.framework */,
 			);
 			name = Frameworks;
@@ -305,17 +292,6 @@
 		BE3808491FD9BFB600393EB8 = {
 			isa = PBXGroup;
 			children = (
-				22F5682D2020CA66009850FD /* libtext.dylib */,
-				22F568272020CA2E009850FD /* libawk.dylib */,
-				22F568282020CA2E009850FD /* libcurl.dylib */,
-				22F568292020CA2E009850FD /* libfiles.dylib */,
-				22F568242020CA2E009850FD /* libshell.dylib */,
-				22F568252020CA2E009850FD /* libssh_cmd.dylib */,
-				22F568262020CA2E009850FD /* libtar.dylib */,
-				22AC09DB202056D6006F7D8B /* libcurl.dylib */,
-				2285423F201FC4E700B93589 /* libtar.dylib */,
-				228541D7201FB62C00B93589 /* libfiles.dylib */,
-				228541DC201FB78200B93589 /* ios_system.framework */,
 				BE3808541FD9BFB600393EB8 /* OpenTerm */,
 				BEC75BFB202B716600216462 /* OpenTermTests */,
 				BE3808531FD9BFB600393EB8 /* Products */,
@@ -408,8 +384,6 @@
 		EDE154E4BB3A66786AACAA5C /* Pods */ = {
 			isa = PBXGroup;
 			children = (
-				D73213876015994510AC49C0 /* Pods-Terminal.debug.xcconfig */,
-				24F6A88F715402F565B82F26 /* Pods-Terminal.release.xcconfig */,
 				448CC7691FD84EB5D2C24705 /* Pods-OpenTerm.debug.xcconfig */,
 				D4433523D5E174B363623AD4 /* Pods-OpenTerm.release.xcconfig */,
 			);
@@ -430,7 +404,7 @@
 				BE000C0B1FEC4F7000D06B91 /* Embed Frameworks */,
 				7E594A5DD24920828A657E90 /* [CP] Embed Pods Frameworks */,
 				0817298A6DFC720C403FB709 /* [CP] Copy Pods Resources */,
-				BEE23C96202A35AD00D038C6 /* ShellScript */,
+				BEE23C96202A35AD00D038C6 /* SwiftLint */,
 			);
 			buildRules = (
 			);
@@ -589,13 +563,14 @@
 			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-OpenTerm/Pods-OpenTerm-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		BEE23C96202A35AD00D038C6 /* ShellScript */ = {
+		BEE23C96202A35AD00D038C6 /* SwiftLint */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
 			);
+			name = SwiftLint;
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;


### PR DESCRIPTION
Lots of miscellaneous stuff was in the Xcodeproj. This change cleans it up and organizes it better. No changes were made to build settings or source files.

- Moved ios_system dylibs out of root group into `Frameworks` group
- Removed references to `PanelKit.framework`, which was replaced by the PanelKit pod
- Removed multiple references to `ios_system.framework`. Only need one.
- Renamed "Run Script" build phase to "SwiftLint"
- Removed reference to `Pods-Terminal.debug.xcconfig` and `Pods-Terminal.release.xcconfig`