### PR TITLE
Managing multiple sessions: interrupt the right command, forget previous directories

### DIFF
--- a/OpenTerm/Controller/TerminalViewController.swift
+++ b/OpenTerm/Controller/TerminalViewController.swift
@@ -427,6 +427,7 @@ extension TerminalViewController: TerminalViewDelegate {
 
 		if command == "exit" {
 			if let parent = self.parent as? TerminalTabViewController {
+				terminalView.executor.closeSession()
 				parent.closeTab(self)
 			}
 			return

--- a/OpenTerm/Util/Execution/CommandExecutor.swift
+++ b/OpenTerm/Util/Execution/CommandExecutor.swift
@@ -142,7 +142,7 @@ class CommandExecutor {
 		guard self.state == .running, let data = input.data(using: .utf8) else {
 			return
 		}
-		
+		ios_switchSession(self.stdout_file)
 		switch input {
 		case Parser.Code.endOfText.rawValue, Parser.Code.endOfTransmission.rawValue:
 			// Kill running process in the current session (tab) on CTRL+C or CTRL+D.


### PR DESCRIPTION
When there are multiple tabs open, iOS_system needs to know which tab is active, and operate accordingly (storing the previous directory, so "cd -" does the right thing, also storing command status into variables that are local to each tab, storing command response separately for each tab).

When a tab is closed, iOS_system needs to know it is, so it deallocates the associated structure. 
Most of the changes are in ios_system (I updated the submodule to 69a4bcc) but a few are in OpenTerm:  `ios_switchSession()` to warn iOS_system about which tab is currently active, `ios_closeSession()` when that session is closed. Sessions can be indexed by any pointer that is unique to them (I used `self.stdout_file`). 

As it is, running commands in parallel in multiple tabs does not work: OpenTerm waits for the current command to exit before it starts the new one. I'm not sure why (commands are called inside `executionQueue.async`, so it should not be blocking), but once this is fixed, this PR ensures that pressing Ctrl-C in a tab ends the command currently running in that tab (as opposed to the command in another tab). 