### PR TITLE
Convert flatMap to convertMap for nullable object mapping

### DIFF
--- a/OpenTerm/Util/Parsing & Formatting/ANSITextState.swift
+++ b/OpenTerm/Util/Parsing & Formatting/ANSITextState.swift
@@ -216,7 +216,7 @@ struct ANSITextState {
 
 	mutating func parse(escapeCodes: String) {
 		// Codes will be a colon-separated string of integers. For each one, adjust our state
-		let codes = escapeCodes.components(separatedBy: ";").flatMap { Int($0) }
+		let codes = escapeCodes.components(separatedBy: ";").compactMap { Int($0) }
 		var index = codes.startIndex
 		while index < codes.endIndex {
 			let code = codes[index]

--- a/OpenTerm/Util/Scripting/Script.swift
+++ b/OpenTerm/Util/Scripting/Script.swift
@@ -39,7 +39,7 @@ class Script {
 	/// Replace argument templates with argument values
 	func runnableCommands(withArgs args: [String]) throws -> [String] {
 		// Step 1: Parse arguments from "--argname=value" to dictionary ["argname": "value"]
-		let argDict: [String: String] = Dictionary(uniqueKeysWithValues: args.flatMap({ arg in
+		let argDict: [String: String] = Dictionary(uniqueKeysWithValues: args.compactMap({ arg in
 			let components = arg.components(separatedBy: "=")
 			guard let name = components.first, let value = components.last else { return nil }
 			return (name.replacingOccurrences(of: "--", with: ""), value)
@@ -66,7 +66,7 @@ class Script {
 	/// The names of the arguments, unique, and sorted by name
 	var argumentNames: [String] {
 		let matches = Script.argumentRegex.matches(in: value, options: [], range: NSRange(location: 0, length: value.count))
-		return Set(matches.flatMap { result in
+		return Set(matches.compactMap { result in
 			let match = result.range(at: 1)
 			if let range = Range(match, in: value) {
 				return String(value[range])

--- a/OpenTerm/View/TerminalView+AutoComplete.swift
+++ b/OpenTerm/View/TerminalView+AutoComplete.swift
@@ -238,7 +238,7 @@ extension TerminalView: AutoCompleteManagerDataSource {
 
 		do {
 			let contents = try DocumentManager.shared.fileManager.contentsOfDirectory(at: directory, includingPropertiesForKeys: [.isDirectoryKey], options: [])
-			return try contents.flatMap { url in
+			return try contents.compactMap { url in
 				let resourceValues = try url.resourceValues(forKeys: [.isDirectoryKey])
 				let isDirectory = resourceValues.isDirectory ?? false
 				if showFolders && isDirectory || showFiles && !isDirectory {


### PR DESCRIPTION
This PR migrates usages of `flatMap` to `compactMap` where there is a potential for the mapping to return a nil object. This migration is part of adherence to changes in Swift 4.1, specifically [SE-0187](https://github.com/apple/swift-evolution/blob/master/proposals/0187-introduce-filtermap.md).