### PR TITLE
Hide autocompletion label if the user hasn't typed anything yet

### DIFF
--- a/OpenTerm/Commands/Credits/authors.json
+++ b/OpenTerm/Commands/Credits/authors.json
@@ -25,5 +25,9 @@
 	},
 	{
 		"name": "Bas Broek"
-	}
+	},
+ 	{
+ 		"name": "Filippo Claudi"
+ 	}
+
 ]

--- a/OpenTerm/View/TerminalView.swift
+++ b/OpenTerm/View/TerminalView.swift
@@ -39,10 +39,11 @@ class TerminalView: UIView {
 	
 	func updateCompletion() {
 		
-		guard let completion = self.autoCompleteManager.completions.first else {
+		guard let completion = self.autoCompleteManager.completions.first, currentCommand != "" else {
 			textView.autoCompletion = ""
 			return
 		}
+		
 		
 		let completionString: String
 		


### PR DESCRIPTION
Implemented the simple check I was talking about yesterday.
If I haven't typed anything yet I'd rather have no autocompletion. as soon as I type the autocompletion will appear