### PR TITLE
Removed the need to MangleFunctionNames for functions sent to ios_system

### DIFF
--- a/OpenTerm/Commands/Clipboard.swift
+++ b/OpenTerm/Commands/Clipboard.swift
@@ -9,11 +9,13 @@
 import UIKit
 import ios_system
 
+@_cdecl("pbpaste")
 public func pbpaste(argc: Int32, argv: UnsafeMutablePointer<UnsafeMutablePointer<Int8>?>?) -> Int32 {
 	fputs(UIPasteboard.general.string ?? "", thread_stdout)
 	return 0
 }
 
+@_cdecl("pbcopy")
 public func pbcopy(argc: Int32, argv: UnsafeMutablePointer<UnsafeMutablePointer<Int8>?>?) -> Int32 {
 	var bytes = [Int8]()
 	while true {

--- a/OpenTerm/Commands/Credits/Credits.swift
+++ b/OpenTerm/Commands/Credits/Credits.swift
@@ -10,6 +10,7 @@ import Foundation
 import ios_system
 import TabView
 
+@_cdecl("credits")
 public func credits(argc: Int32, argv: UnsafeMutablePointer<UnsafeMutablePointer<Int8>?>?) -> Int32 {
 	
 	let logoFileName: String

--- a/OpenTerm/Commands/Cub.swift
+++ b/OpenTerm/Commands/Cub.swift
@@ -11,6 +11,7 @@ import Cub
 import ios_system
 import TabView
 
+@_cdecl("cub")
 public func cub(argc: Int32, argv: UnsafeMutablePointer<UnsafeMutablePointer<Int8>?>?) -> Int32 {
 
 	guard let tabViewContainer = UIApplication.shared.keyWindow?.rootViewController as? TabViewContainerViewController<TerminalTabViewController> else {

--- a/OpenTerm/Commands/Say.swift
+++ b/OpenTerm/Commands/Say.swift
@@ -10,6 +10,7 @@ import Foundation
 import ios_system
 import AVFoundation
 
+@_cdecl("say")
 public func say(argc: Int32, argv: UnsafeMutablePointer<UnsafeMutablePointer<Int8>?>?) -> Int32 {
 
 	guard let args = convertCArguments(argc: argc, argv: argv) else {

--- a/OpenTerm/Commands/Share.swift
+++ b/OpenTerm/Commands/Share.swift
@@ -11,6 +11,7 @@ import ios_system
 
 public weak var shareFileViewController: UIViewController?
 
+@_cdecl("shareFile")
 public func shareFile(argc: Int32, argv: UnsafeMutablePointer<UnsafeMutablePointer<Int8>?>?) -> Int32 {
 	var itemsToShare = [Any]()
 

--- a/OpenTerm/Commands/xCallBackUrl.swift
+++ b/OpenTerm/Commands/xCallBackUrl.swift
@@ -62,6 +62,7 @@ public func xCallbackUrlOpen(_ url: URL) -> Bool {
 	}
 }
 
+@_cdecl("openUrl")
 public func openUrl(argc: Int32, argv: UnsafeMutablePointer<UnsafeMutablePointer<Int8>?>?) -> Int32 {
 	var url: URL? = nil
 	if argc == 2 {

--- a/OpenTerm/Controller/TerminalViewController.swift
+++ b/OpenTerm/Controller/TerminalViewController.swift
@@ -134,13 +134,13 @@ class TerminalViewController: UIViewController {
 		NotificationCenter.default.addObserver(self, selector: #selector(applicationDidEnterBackground), name: .UIApplicationDidEnterBackground, object: nil)
 
 		initializeEnvironment()
-		replaceCommand("open-url", mangleFunctionName("openUrl"), true)
-		replaceCommand("share", mangleFunctionName("shareFile"), true)
-		replaceCommand("pbcopy", mangleFunctionName("pbcopy"), true)
-		replaceCommand("pbpaste", mangleFunctionName("pbpaste"), true)
-		replaceCommand("cub", mangleFunctionName("cub"), true)
-		replaceCommand("credits", mangleFunctionName("credits"), true)
-		replaceCommand("say", mangleFunctionName("say"), true)
+		replaceCommand("open-url", "openUrl", true)
+		replaceCommand("share", "shareFile", true)
+		replaceCommand("pbcopy", "pbcopy", true)
+		replaceCommand("pbpaste", "pbpaste", true)
+		replaceCommand("cub", "cub", true)
+		replaceCommand("credits", "credits", true)
+		replaceCommand("say", "say", true)
 
 		// Call reloadData for the added commands.
 		terminalView.autoCompleteManager.reloadData()
@@ -193,13 +193,6 @@ class TerminalViewController: UIViewController {
 		super.traitCollectionDidChange(previousTraitCollection)
 
 		self.overflowState = self.traitCollection.horizontalSizeClass == .compact ? .compact : .expanded
-	}
-
-	private func mangleFunctionName(_ functionName: String) -> String {
-		// This works because all functions have the same signature:
-		// (argc: Int32, argv: UnsafeMutablePointer<UnsafeMutablePointer<Int8>?>?) -> Int32
-		// The first part is the class name: _T0 + length + name. To change if not "OpenTerm"
-		return "_T08OpenTerm" + String(functionName.count) + functionName + "s5Int32VAD4argc_SpySpys4Int8VGSgGSg4argvtF"
 	}
 
 	func setSSLCertIfNeeded() {


### PR DESCRIPTION
`ios_system` uses dynamic libraries, and thus uses `dlsym()`, that refers to functions by their names. Functions in Swift (and other OO languages) have a complicated name that encodes the class name, the function name and the arguments. So far, we used `mangleFunctionName` to convert from Swift names to C names that `dlsym()` likes. 

This PR uses the operator `@_cdecl("functionName")` which lets us give any C name to a Swift function, removing the need for `mangleFunctionName`. 